### PR TITLE
Send a activation email when not in debug mode

### DIFF
--- a/wasa2il/settings.py
+++ b/wasa2il/settings.py
@@ -173,3 +173,6 @@ ACCOUNT_ACTIVATION_DAYS = 7
 LOGIN_REDIRECT_URL = "/"
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
+# Only send activation emails if we aren't in debug mode
+SEND_ACTIVATION_EMAIL = not DEBUG


### PR DESCRIPTION
I was getting a error when trying to sign up on my dev setup since the app was trying to connect to some server to send an email.

This still means that anyone that wants to set up the app needs to set the user as active manually in the database after registering but at least we don't get an error :stuck_out_tongue_winking_eye: