### PR TITLE
2 changes: Modifiable change proposals and a page for new issues

### DIFF
--- a/wasa2il/core/ajax/document.py
+++ b/wasa2il/core/ajax/document.py
@@ -14,6 +14,7 @@ from google_diff_match_patch.diff_match_patch import diff_match_patch
 @jsonize
 def document_propose_change(request):
     ctx = {"ok": True}
+    version_num = int(request.POST.get('v', 0))
     document = get_object_or_404(Document, id=request.POST.get("document_id", 0))
 
     try:
@@ -21,24 +22,45 @@ def document_propose_change(request):
     except KeyError:
         raise Exception('Missing "text"')
 
-    predecessor = document.preferred_version()
-    if predecessor and predecessor.text.strip() == text.strip():
-        # This error message won't show anywhere. The same error is caught client-side to produce the error message.
-        raise Exception('Change proposal must differ from its predecessor')
+    if version_num == 0:
+        predecessor = document.preferred_version()
+        if predecessor and predecessor.text.strip() == text.strip():
+            # This error message won't show anywhere. The same error is caught client-side to produce the error message.
+            raise Exception('Change proposal must differ from its predecessor')
 
-    content = DocumentContent()
-    content.user = request.user
-    content.document = document
-    content.text = text
-    content.comments = request.POST.get('comments', '')
-    content.predecessor = predecessor
-    # TODO: Change this to a query that requests the maximum 'order' and adds to it.
-    try:
-        content.order = DocumentContent.objects.filter(document=document).order_by('-order')[0].order + 1
-    except IndexError:
-        pass
+        content = DocumentContent()
+        content.user = request.user
+        content.document = document
+        content.predecessor = predecessor
+        content.text = text
+        content.comments = request.POST.get('comments', '')
+        # TODO: Change this to a query that requests the maximum 'order' and adds to it.
+        try:
+            content.order = DocumentContent.objects.filter(document=document).order_by('-order')[0].order + 1
+        except IndexError:
+            pass
 
-    content.save()
+        content.save()
+
+    else:
+        try:
+            content = DocumentContent.objects.get(
+                document=document,
+                user=request.user.id,
+                order=version_num,
+                status='proposed',
+                issue=None
+            )
+            content.text = text
+            content.comments = request.POST.get('comments', '')
+
+            content.save()
+        except DocumentContent.DoesNotExist:
+            raise Exception('The user "%s" maliciously tried changing document "%s", version %d' % (
+                request.user,
+                document,
+                version_num
+            ))
 
     ctx['order'] = content.order
 

--- a/wasa2il/core/urls.py
+++ b/wasa2il/core/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import patterns
+from django.conf.urls import url
 from django.views.generic import ListView
 from django.views.generic import UpdateView
 from django.views.generic import DetailView
@@ -27,6 +28,7 @@ urlpatterns = patterns('',
     (r'^issue/(?P<pk>\d+)/edit/$', login_required(UpdateView.as_view(model=Issue, success_url="/issue/%(id)d/"))),
     (r'^issue/(?P<pk>\d+)/$', IssueDetailView.as_view()),
 
+    url(r'^polity/(?P<polity>\d+)/issues/open/$', IssueOpenListView.as_view(), name='polity_issues_new'),
     (r'^polity/(?P<polity>\d+)/issue/new/(documentcontent/(?P<documentcontent>\d+)/)?$', login_required(IssueCreateView.as_view())),
 
     (r'^search/$', SearchListView.as_view()),

--- a/wasa2il/core/views.py
+++ b/wasa2il/core/views.py
@@ -421,6 +421,24 @@ class IssueDetailView(DetailView):
         return context_data
 
 
+class IssueOpenListView(ListView):
+    model = Issue
+    context_object_name = 'newissues'
+    template_name = "core/issues_new.html"
+
+    def dispatch(self, *args, **kwargs):
+        self.polity = get_object_or_404(Polity, id=kwargs['polity'])
+        return super(IssueOpenListView, self).dispatch(*args, **kwargs)
+
+    def get_queryset(self):
+        return self.polity.issue_set.order_by('deadline_votes').filter(deadline_votes__gt=datetime.now())
+
+    def get_context_data(self, *args, **kwargs):
+        context_data = super(IssueOpenListView, self).get_context_data(*args, **kwargs)
+        context_data.update({'polity': self.polity})
+        return context_data
+
+
 class PolityDetailView(DetailView):
     model = Polity
     context_object_name = "polity"

--- a/wasa2il/locale/is/LC_MESSAGES/django.po
+++ b/wasa2il/locale/is/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wasa2il\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-04 21:00+0000\n"
+"POT-Creation-Date: 2016-01-24 17:36+0000\n"
 "PO-Revision-Date: 2013-01-31 22:03+0100\n"
 "Last-Translator: smari <smari@immi.is>\n"
 "Language-Team: Icelandic\n"
@@ -143,7 +143,6 @@ msgid "Topic"
 msgstr "Málaflokkur"
 
 #: core/models.py:385 templates/core/polity_list.html:16
-#: templates/profile.html:50
 msgid "Polity"
 msgstr "Þing"
 
@@ -185,7 +184,7 @@ msgstr "Skráningarmörk meðlima"
 msgid "Instructions"
 msgstr "Leiðbeiningar"
 
-#: core/views.py:377
+#: core/views.py:419
 msgid "voting"
 msgstr "atkvæðagreiðsla"
 
@@ -245,15 +244,15 @@ msgid "Logout"
 msgstr "Útskrá"
 
 #: templates/base.html:103 templates/entry.html:17
-#: templates/registration/login.html:12
+#: templates/registration/login.html:6
 #: templates/registration/password_reset_complete.html:9
 msgid "Log in"
 msgstr "Innskrá"
 
 #: templates/base.html:104 templates/entry.html:11
-#: templates/registration/login.html:25
-#: templates/registration/registration_form.html:12
-#: templates/registration/registration_form.html:23
+#: templates/registration/login.html:19
+#: templates/registration/registration_form.html:6
+#: templates/registration/registration_form.html:17
 msgid "Sign up"
 msgstr "Nýskrá"
 
@@ -403,7 +402,7 @@ msgid "Remove"
 msgstr ""
 
 #: templates/core/_election_candidate_list.html:17
-#: templates/core/issue_detail.html:76
+#: templates/core/issue_detail.html:77
 msgid "Vote"
 msgstr "Kjósa"
 
@@ -442,11 +441,11 @@ msgstr "Opið"
 msgid "Closed"
 msgstr "Lokað"
 
-#: templates/core/_topic_list_table.html:17
+#: templates/core/_topic_list_table.html:19
 msgid "There are no topics in this polity!"
 msgstr "Það eru engir málaflokkar á þessu þingi!"
 
-#: templates/core/_topic_list_table.html:18
+#: templates/core/_topic_list_table.html:20
 msgid "Start a new topic"
 msgstr "Stofna nýjan málaflokk"
 
@@ -515,18 +514,18 @@ msgstr "Forsendur"
 msgid "Declarations"
 msgstr "Ályktanir"
 
-#: templates/core/document_form.html:17
+#: templates/core/document_form.html:6
 msgid "New Document"
 msgstr "Nýtt skjal"
 
-#: templates/core/document_form.html:20
+#: templates/core/document_form.html:9
 msgid "In polity:"
 msgstr "Í þingi:"
 
-#: templates/core/document_form.html:29
+#: templates/core/document_form.html:18
 #: templates/core/document_update.html:121
-#: templates/core/election_form.html:37 templates/core/issue_form.html:32
-#: templates/core/polity_form.html:24 templates/core/topic_form.html:25
+#: templates/core/election_form.html:35 templates/core/issue_form.html:30
+#: templates/core/polity_form.html:13 templates/core/topic_form.html:14
 #: templates/forum/discussion_form.html:16 templates/forum/forum_form.html:17
 #: templates/registration/password_change_form.html:21
 #: templates/registration/password_reset_confirm.html:14
@@ -547,16 +546,16 @@ msgstr "Skjöl"
 msgid "Change proposal must differ from its predecessor."
 msgstr "Breytingatillaga verður að vera öðruvísi en upprunatexti."
 
-#: templates/core/document_update.html:91
+#: templates/core/document_update.html:88
 msgid "Agreement"
 msgstr "Samþykkt"
 
-#: templates/core/document_update.html:93 templates/core/issue_detail.html:22
+#: templates/core/document_update.html:90 templates/core/issue_detail.html:22
 msgid "Proposal"
 msgstr "Tillaga"
 
 #: templates/core/document_update.html:115
-#: templates/core/document_update.html:184
+#: templates/core/document_update.html:188
 #: templates/core/polity_detail.html:91 templates/core/topic_detail.html:23
 msgid "Comments"
 msgstr "Ummæli"
@@ -583,28 +582,32 @@ msgstr "Hætta við"
 msgid "Propose change"
 msgstr "Stinga upp á breytingu"
 
-#: templates/core/document_update.html:141
-#: templates/core/document_update.html:143
+#: templates/core/document_update.html:140
+msgid "Edit proposal"
+msgstr "Breyta tillögu"
+
+#: templates/core/document_update.html:145
+#: templates/core/document_update.html:147
 msgid "Put to vote"
 msgstr "Setja í kosningu"
 
-#: templates/core/document_update.html:162
+#: templates/core/document_update.html:166
 msgid "Referenced issue"
 msgstr "Tilheyrandi mál"
 
-#: templates/core/document_update.html:178
+#: templates/core/document_update.html:182
 msgid "Versions"
 msgstr "Útgáfur"
 
-#: templates/core/document_update.html:182
+#: templates/core/document_update.html:186
 msgid "Status"
 msgstr "Ástand"
 
-#: templates/core/document_update.html:183
+#: templates/core/document_update.html:187
 msgid "Author"
 msgstr "Höfundur"
 
-#: templates/core/document_update.html:202
+#: templates/core/document_update.html:206
 msgid "New draft"
 msgstr "Ný drög"
 
@@ -651,7 +654,7 @@ msgstr ""
 msgid "Election results"
 msgstr "Niðurstöður kosningar"
 
-#: templates/core/election_detail.html:71 templates/core/issue_detail.html:77
+#: templates/core/election_detail.html:71 templates/core/issue_detail.html:78
 msgid "There was an error while processing your vote. Please try again."
 msgstr ""
 "Það kom upp villa við úrvinnslu atkvæðisins þíns. Vinsamlegast reyndu aftur."
@@ -672,7 +675,7 @@ msgstr "Tilkynna framboð"
 msgid "Withdraw candidacy"
 msgstr "Draga framboð til baka"
 
-#: templates/core/election_form.html:30 templates/core/polity_detail.html:116
+#: templates/core/election_form.html:28 templates/core/polity_detail.html:116
 msgid "New election"
 msgstr "Ný kosning"
 
@@ -705,11 +708,11 @@ msgstr "Tímamörk fyrir umræður"
 msgid "Deadline for proposals"
 msgstr "Tímamörk fyrir tillögur"
 
-#: templates/core/issue_detail.html:44 templates/core/issue_detail.html:79
+#: templates/core/issue_detail.html:44 templates/core/issue_detail.html:80
 msgid "Yes"
 msgstr "Já"
 
-#: templates/core/issue_detail.html:45 templates/core/issue_detail.html:81
+#: templates/core/issue_detail.html:45 templates/core/issue_detail.html:82
 msgid "No"
 msgstr "Nei"
 
@@ -722,16 +725,16 @@ msgstr "Meirihlutaþröskuldur"
 msgid "Discussion"
 msgstr "Umræða"
 
-#: templates/core/issue_detail.html:67
+#: templates/core/issue_detail.html:68
 #: templates/forum/discussion_detail.html:23
 msgid "Add comment"
 msgstr "Bæta við ummælum"
 
-#: templates/core/issue_detail.html:76
+#: templates/core/issue_detail.html:77
 msgid "for or against this issue"
 msgstr "með eða á móti þessu máli"
 
-#: templates/core/issue_detail.html:80
+#: templates/core/issue_detail.html:81
 msgid "Abstain"
 msgstr "Sitja hjá"
 
@@ -739,7 +742,7 @@ msgstr "Sitja hjá"
 msgid "version"
 msgstr "útgáfa"
 
-#: templates/core/issue_form.html:24
+#: templates/core/issue_form.html:22
 msgid "New issue"
 msgstr "Nýtt mál"
 
@@ -763,7 +766,7 @@ msgstr "samþykktir"
 msgid "subpolities"
 msgstr "undirþing"
 
-#: templates/core/polity_detail.html:35 templates/core/topic_form.html:17
+#: templates/core/polity_detail.html:35 templates/core/topic_form.html:6
 msgid "New topic"
 msgstr "Nýr málaflokkur"
 
@@ -852,7 +855,7 @@ msgstr "Stundum þarf að setja fólk á sinn stað. Kosningar gera einmitt þa�
 msgid "Subpolities"
 msgstr "Undirþing"
 
-#: templates/core/polity_form.html:17 templates/core/polity_list.html:8
+#: templates/core/polity_form.html:6 templates/core/polity_list.html:8
 msgid "New polity"
 msgstr "Nýtt þing"
 
@@ -878,7 +881,7 @@ msgid "Compared to"
 msgstr "Samanborið við"
 
 #: templates/core/stub/document_view.html:93
-#: templates/core/stub/document_view.html:95 templates/profile.html:61
+#: templates/core/stub/document_view.html:95 templates/profile.html:53
 msgid "Version"
 msgstr "Útgáfa"
 
@@ -1867,13 +1870,9 @@ msgstr ""
 msgid "Summary"
 msgstr "Yfirlit"
 
-#: templates/profile.html:32
+#: templates/profile.html:37
 msgid "This user hasn't provided a biography."
 msgstr "Þessi notandi hefur ekki skrifað lýsingu á sjálfum sér."
-
-#: templates/profile.html:69
-msgid "is not viewable by non-members."
-msgstr "er ekki sýnilegt þeim sem eru ekki meðlimir."
 
 #: templates/registration/activate.html:5
 msgid "Welcome to Wasa2il!"
@@ -1897,7 +1896,7 @@ msgid "You may now try to log in!"
 msgstr "Þú getur núna reynt að innskrá þig!"
 
 #: templates/registration/activation_complete.html:13
-#: templates/registration/login.html:24
+#: templates/registration/login.html:18
 msgid "Login"
 msgstr "Innskrá"
 
@@ -1968,12 +1967,12 @@ msgstr ""
 "Ef einhverjar spurningar vakna varðandi persónugögn, vinsamlegast sendið "
 "okkur tölvupóst:"
 
-#: templates/registration/login.html:12
-#: templates/registration/registration_form.html:12
+#: templates/registration/login.html:6
+#: templates/registration/registration_form.html:6
 msgid "and partake in democracy..."
 msgstr "og taktu þátt í lýðræðinu..."
 
-#: templates/registration/login.html:14
+#: templates/registration/login.html:8
 msgid ""
 "Please note that as of February 12th 2014, we require the verification of "
 "all user accounts via the so-called Icekey."
@@ -1981,12 +1980,12 @@ msgstr ""
 "Vinsamlegast athugið að frá og með 12. febrúar 2014 krefjumst við "
 "staðfestingar allra innskráðra notenda með hinum svokallaða Íslykli."
 
-#: templates/registration/login.html:15
+#: templates/registration/login.html:9
 msgid "If problems arise, please send an email to the following email address:"
 msgstr ""
 "Ef vandamál koma upp, vinsamlegast sendið netpóst á eftirfarandi netfang:"
 
-#: templates/registration/login.html:26
+#: templates/registration/login.html:20
 #: templates/registration/password_reset_complete.html:5
 #: templates/registration/password_reset_confirm.html:6
 #: templates/registration/password_reset_done.html:5
@@ -2134,6 +2133,9 @@ msgstr "Stillingar"
 #: templates/settings.html:10
 msgid "You are signed in as"
 msgstr "Þú ert innskráð(ur) sem"
+
+#~ msgid "is not viewable by non-members."
+#~ msgstr "er ekki sýnilegt þeim sem eru ekki meðlimir."
 
 #~ msgid "Password changed"
 #~ msgstr "Lykilorði breytt"
@@ -2322,9 +2324,6 @@ msgstr "Þú ert innskráð(ur) sem"
 #, fuzzy
 #~ msgid "Version status"
 #~ msgstr "Ályktanir"
-
-#~ msgid "Draft proposal"
-#~ msgstr "Drög að tillögu"
 
 #~ msgid "Closed elections"
 #~ msgstr "Lokaðar kosningar"

--- a/wasa2il/locale/is/LC_MESSAGES/django.po
+++ b/wasa2il/locale/is/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wasa2il\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-24 17:36+0000\n"
+"POT-Creation-Date: 2016-01-27 19:51+0000\n"
 "PO-Revision-Date: 2013-01-31 22:03+0100\n"
 "Last-Translator: smari <smari@immi.is>\n"
 "Language-Team: Icelandic\n"
@@ -134,7 +134,8 @@ msgstr "Reglur"
 msgid "Special process"
 msgstr "Sérstakur ferill"
 
-#: core/models.py:375 templates/core/polity_detail.html:89
+#: core/models.py:375 templates/core/issues_new.html:18
+#: templates/core/polity_detail.html:96
 msgid "Issue"
 msgstr "Málefni"
 
@@ -367,7 +368,7 @@ msgid "Statements:"
 msgstr "Statements:"
 
 #: templates/core/_document_modal.html:49
-#: templates/core/polity_detail.html:165 templates/core/topic_detail.html:72
+#: templates/core/polity_detail.html:172 templates/core/topic_detail.html:72
 #: templates/forum/forum_detail.html:48
 msgid "Close"
 msgstr "Loka"
@@ -425,14 +426,14 @@ msgid "You have not voted in this election"
 msgstr "You have not voted on this issue"
 
 #: templates/core/_election_list_table.html:11
-#: templates/core/election_list.html:25 templates/core/polity_detail.html:103
-#: templates/core/topic_detail.html:34
+#: templates/core/election_list.html:25 templates/core/issues_new.html:32
+#: templates/core/polity_detail.html:110 templates/core/topic_detail.html:34
 msgid "Voting"
 msgstr "Í kosningu"
 
 #: templates/core/_election_list_table.html:11
-#: templates/core/election_list.html:25 templates/core/polity_detail.html:103
-#: templates/core/topic_detail.html:34
+#: templates/core/election_list.html:25 templates/core/issues_new.html:32
+#: templates/core/polity_detail.html:110 templates/core/topic_detail.html:34
 msgid "Open"
 msgstr "Opið"
 
@@ -452,8 +453,8 @@ msgstr "Stofna nýjan málaflokk"
 #: templates/core/delegate_detail.html:6
 #: templates/core/document_detail.html:14
 #: templates/core/election_detail.html:7 templates/core/election_list.html:8
-#: templates/core/issue_detail.html:6 templates/core/topic_detail.html:7
-#: templates/forum/discussion_detail.html:6
+#: templates/core/issue_detail.html:6 templates/core/issues_new.html:8
+#: templates/core/topic_detail.html:7 templates/forum/discussion_detail.html:6
 #: templates/forum/forum_detail.html:7
 msgid "Back to polity"
 msgstr "Fara aftur í þing"
@@ -555,8 +556,8 @@ msgid "Proposal"
 msgstr "Tillaga"
 
 #: templates/core/document_update.html:115
-#: templates/core/document_update.html:188
-#: templates/core/polity_detail.html:91 templates/core/topic_detail.html:23
+#: templates/core/document_update.html:192 templates/core/issues_new.html:20
+#: templates/core/polity_detail.html:98 templates/core/topic_detail.html:23
 msgid "Comments"
 msgstr "Ummæli"
 
@@ -582,32 +583,33 @@ msgstr "Hætta við"
 msgid "Propose change"
 msgstr "Stinga upp á breytingu"
 
-#: templates/core/document_update.html:140
+#: templates/core/document_update.html:141
+#: templates/core/document_update.html:143
 msgid "Edit proposal"
 msgstr "Breyta tillögu"
 
-#: templates/core/document_update.html:145
-#: templates/core/document_update.html:147
+#: templates/core/document_update.html:149
+#: templates/core/document_update.html:151
 msgid "Put to vote"
 msgstr "Setja í kosningu"
 
-#: templates/core/document_update.html:166
+#: templates/core/document_update.html:170
 msgid "Referenced issue"
 msgstr "Tilheyrandi mál"
 
-#: templates/core/document_update.html:182
+#: templates/core/document_update.html:186
 msgid "Versions"
 msgstr "Útgáfur"
 
-#: templates/core/document_update.html:186
+#: templates/core/document_update.html:190
 msgid "Status"
 msgstr "Ástand"
 
-#: templates/core/document_update.html:187
+#: templates/core/document_update.html:191
 msgid "Author"
 msgstr "Höfundur"
 
-#: templates/core/document_update.html:206
+#: templates/core/document_update.html:210
 msgid "New draft"
 msgstr "Ný drög"
 
@@ -630,14 +632,15 @@ msgstr "View details."
 
 #: templates/core/election_detail.html:26
 #: templates/core/election_detail.html:70 templates/core/election_list.html:18
-#: templates/core/issue_detail.html:42 templates/core/polity_detail.html:92
-#: templates/core/polity_detail.html:136 templates/core/topic_detail.html:24
+#: templates/core/issue_detail.html:42 templates/core/issues_new.html:21
+#: templates/core/polity_detail.html:99 templates/core/polity_detail.html:143
+#: templates/core/topic_detail.html:24
 msgid "Votes"
 msgstr "Atkvæði"
 
 #: templates/core/election_detail.html:27
 #: templates/core/election_detail.html:80 templates/core/election_list.html:17
-#: templates/core/polity_detail.html:135
+#: templates/core/polity_detail.html:142
 msgid "Candidates"
 msgstr "Frambjóðendur"
 
@@ -675,7 +678,7 @@ msgstr "Tilkynna framboð"
 msgid "Withdraw candidacy"
 msgstr "Draga framboð til baka"
 
-#: templates/core/election_form.html:28 templates/core/polity_detail.html:116
+#: templates/core/election_form.html:28 templates/core/polity_detail.html:123
 msgid "New election"
 msgstr "Ný kosning"
 
@@ -683,12 +686,13 @@ msgstr "Ný kosning"
 msgid "Elections in polity"
 msgstr "Kosningar í þingi"
 
-#: templates/core/election_list.html:15 templates/core/polity_detail.html:133
+#: templates/core/election_list.html:15 templates/core/polity_detail.html:140
 msgid "Election"
 msgstr "Kosning"
 
-#: templates/core/election_list.html:16 templates/core/polity_detail.html:90
-#: templates/core/polity_detail.html:134 templates/core/topic_detail.html:22
+#: templates/core/election_list.html:16 templates/core/issues_new.html:19
+#: templates/core/polity_detail.html:97 templates/core/polity_detail.html:141
+#: templates/core/topic_detail.html:22
 msgid "State"
 msgstr "Ástand"
 
@@ -745,6 +749,32 @@ msgstr "útgáfa"
 #: templates/core/issue_form.html:22
 msgid "New issue"
 msgstr "Nýtt mál"
+
+#: templates/core/issues_new.html:10 templates/core/polity_detail.html:89
+msgid "New issues"
+msgstr "Ný mál"
+
+#: templates/core/issues_new.html:10 templates/core/polity_detail.html:89
+msgid "in discussion"
+msgstr "til umræðu"
+
+#: templates/core/issues_new.html:11 templates/core/polity_detail.html:91
+msgid "These are the newest issues being discussed in this polity."
+msgstr "Þetta eru nýjustu málin til umræðu í þessu þingi."
+
+#: templates/core/issues_new.html:29 templates/core/polity_detail.html:107
+#: templates/core/topic_detail.html:30
+msgid "You have voted on this issue"
+msgstr "Þú hefur greitt atkvæði í þessu máli"
+
+#: templates/core/issues_new.html:29 templates/core/polity_detail.html:107
+#: templates/core/topic_detail.html:30
+msgid "You have not voted on this issue"
+msgstr "Þú hefur ekki greitt atkvæði í þessu máli"
+
+#: templates/core/issues_new.html:32 templates/core/polity_detail.html:110
+msgid "New"
+msgstr ""
 
 #: templates/core/polity_detail.html:9
 msgid "You are an officer in this polity."
@@ -806,52 +836,32 @@ msgstr "þessa þings"
 msgid "Here are all of the agreements this polity has arrived at."
 msgstr "Hér eru allar samþykktir þessa þings."
 
-#: templates/core/polity_detail.html:82
-msgid "New issues"
-msgstr "Ný mál"
+#: templates/core/polity_detail.html:85
+msgid "Show all new issues"
+msgstr "Sýna öll ný mál"
 
-#: templates/core/polity_detail.html:82
-msgid "in discussion"
-msgstr "til umræðu"
-
-#: templates/core/polity_detail.html:84
-msgid "These are the newest issues being discussed in this polity."
-msgstr "Þetta eru nýjustu málin til umræðu í þessu þingi."
-
-#: templates/core/polity_detail.html:100 templates/core/topic_detail.html:30
-msgid "You have voted on this issue"
-msgstr "Þú hefur greitt atkvæði í þessu máli"
-
-#: templates/core/polity_detail.html:100 templates/core/topic_detail.html:30
-msgid "You have not voted on this issue"
-msgstr "Þú hefur ekki greitt atkvæði í þessu máli"
-
-#: templates/core/polity_detail.html:103
-msgid "New"
-msgstr ""
-
-#: templates/core/polity_detail.html:121
+#: templates/core/polity_detail.html:128
 msgid "Show closed elections"
 msgstr "Sýna liðnar kosningar"
 
-#: templates/core/polity_detail.html:122
+#: templates/core/polity_detail.html:129
 msgid "Show all elections"
 msgstr "Sýna allar kosningar"
 
-#: templates/core/polity_detail.html:126
+#: templates/core/polity_detail.html:133
 msgid "Elections"
 msgstr "Kosningar"
 
-#: templates/core/polity_detail.html:126
+#: templates/core/polity_detail.html:133
 msgid "putting people in power"
 msgstr "gefa fólki völd"
 
-#: templates/core/polity_detail.html:128
+#: templates/core/polity_detail.html:135
 msgid ""
 "Sometimes you need to put people in their places. Elections do just that."
 msgstr "Stundum þarf að setja fólk á sinn stað. Kosningar gera einmitt það."
 
-#: templates/core/polity_detail.html:155
+#: templates/core/polity_detail.html:162
 msgid "Subpolities"
 msgstr "Undirþing"
 
@@ -2172,9 +2182,6 @@ msgstr "Þú ert innskráð(ur) sem"
 
 #~ msgid "Yes, I want to leave this polity."
 #~ msgstr "Já, ég vil yfirgefa þingið."
-
-#~ msgid "Open issues"
-#~ msgstr "Opin mál"
 
 #~ msgid "followers"
 #~ msgstr "fylgjendur"

--- a/wasa2il/templates/core/document_update.html
+++ b/wasa2il/templates/core/document_update.html
@@ -18,7 +18,7 @@
     <script language="javascript" type="text/javascript">
         $(document).ready(function() {
 
-            var original_text = $('#legal-text-editor').val();
+            var original_text = $('#predecessor-legal-text').val();
 
             $('.document #propose-change').submit(function (e) {
                 input_text = $('#legal-text-editor').val();
@@ -35,6 +35,7 @@
                     '/api/document/propose-change/',
                     {
                         document_id: DOCUMENT_ID,
+                        v: $('input[name="v"]').val(),
                         text: $('#legal-text-editor').val(),
                         comments: $(this).find('#comments').val(),
                         patch: '',
@@ -97,7 +98,10 @@
         <form id="propose-change" action="." method="post">
             {% csrf_token %}
 
+            <input type="hidden" name="v" value="{{ current_content.order }}" />
+
             {% if editor_enabled %}
+                <textarea id="predecessor-legal-text" style="display: none;">{{ current_content.predecessor.text }}</textarea>
                 <textarea id="legal-text-editor">{{ current_content.text }}</textarea>
             {% else %}
                 {% include 'core/stub/document_view.html' with documentcontent=current_content %}
@@ -109,7 +113,7 @@
 
                     <div class="comments">
                         <label for="comments">{% trans 'Comments' %} <small>({% trans 'optional' %})</small>:</label>
-                        <textarea id="comments"></textarea>
+                        <textarea id="comments">{{ current_content.comments }}</textarea>
                     </div>
 
                     <div class="btn-group">
@@ -129,7 +133,15 @@
                 {% else %}
 
                     {% if buttons.propose_change %}
-                        <a class="btn btn-default" role="button" href="?v=new">{% trans "Propose change" %}</a>
+                        <a class="btn btn-default" role="button" href="?action=new">{% trans "Propose change" %}</a>
+                    {% endif %}
+
+                    {% if buttons.edit_proposal %}
+                        {% if buttons.edit_proposal == 'disabled' %}
+                            <a class="btn btn-default disabled" role="button">{% trans "Edit proposal" %}</a>
+                        {% else %}
+                            <a class="btn btn-default" role="button" href="?v={{ current_content.order }}&amp;action=edit">{% trans "Edit proposal" %}</a>
+                        {% endif %}
                     {% endif %}
 
                     {% if buttons.put_to_vote %}
@@ -192,7 +204,7 @@
                 <td>{{ content.comments|linebreaks }}</td>
             </tr>
             {% endfor %}
-            {% if editor_enabled %}
+            {% if action == 'new' %}
                 <tr class="current">
                     <td>-</td>
                     <td><strong>{% trans 'New draft' %}</strong></td>

--- a/wasa2il/templates/core/issues_new.html
+++ b/wasa2il/templates/core/issues_new.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load wasa2il %}
+
+{% block content %}
+
+    <div style="float: right;">
+        <a class="btn btn-default" role="button" href="/polity/{{ polity.id }}">{% trans "Back to polity" %}</a>
+    </div>
+    <h1>{% trans "New issues" %} <small>{% trans "in discussion"%}</small></h1>
+    <p class="muted">{% trans "These are the newest issues being discussed in this polity." %}</p>
+
+    <div class="row">
+
+        <table class="table table-striped table-bordered table-condensed" id="newissues_list">
+        <thead>
+        <tr>
+            <th>{% trans "Issue" %}</th>
+            <th>{% trans "State" %}</th>
+            <th>{% trans "Comments" %}</th>
+            <th>{% trans "Votes" %}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for issue in newissues %}
+            <tr>
+                <td>
+                    <span id="issuestar_{{ issue.id }}" class="glyphicon glyphicon-pencil {% if issue|issuevoted:user %}{% else %}icon-grey{% endif %}"
+                        title="{% if issue|issuevoted:user %}{% trans "You have voted on this issue" %}{% else %}{% trans "You have not voted on this issue" %}{% endif %}"></span>
+                    <a href="/issue/{{ issue.id }}/">{{ issue.name }}</a>
+                </td>
+                <td class="issue-status">{% if issue.is_voting %}{% trans "Voting" %}{% else %}{% if issue.is_open %}{% trans "Open" %}{% else %}{% trans "New" %}{% endif %}{% endif %}</td>
+                <td>{{ issue.comment_set.count }}</td>
+                <td>{{ issue.get_votes.count }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        </table>
+    </div>
+
+{% endblock %}

--- a/wasa2il/templates/core/polity_detail.html
+++ b/wasa2il/templates/core/polity_detail.html
@@ -79,6 +79,13 @@
 
     <div class="col-md-6 col-xs-12"><a name="newissues"></a>
 
+        <div class="btn-group" role="group" style="float: right">
+            <a class="btn btn-default btn-sm dropdown-toggle" role="button" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-list"></span><span class="caret"></span></a>
+            <ul class="dropdown-menu" style="left: -50px;">
+                <li><a href="{% url 'polity_issues_new' polity.id %}">{% trans "Show all new issues" %}</a></li>
+            </ul>
+        </div>
+
         <h2>{% trans "New issues" %} <small>{% trans "in discussion"%}</small></h2>
 
         <p class="muted">{% trans "These are the newest issues being discussed in this polity." %}</p>


### PR DESCRIPTION
1. Ability to change proposals before they're put to a vote

2. An independent page showing all new/open issues in a given polity (handy when there are more than one issue in voting and links need to be pinned on Facebook or something)

Icelandic translations also updated accordingly, each in an independent commit.

Please see individual commits for details in code changes.