### PR TITLE
Simplify installation instructions, fix initial_setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,20 +87,19 @@ possibility of a Condorcet winner. Some middle ground should exist, and Wasa2il
 should support the creation of that.]
 
 
-# Installation
+# Alternative installation instructions
 
-If you don't know what a virtualenv or a docker is, you can safely ignore those
-parts of the instructions.  They are included for those who wish to develop and
-support the project using those technologies.
+If you don't know what a virtualenv or a docker is, you can safely ignore the
+following and just use the [setup instruction above](#setup). Alternatives
+are included for those who wish to develop and support the project using those
+technologies.
 
-## Locally
-
-    python initial_setup.py
-
-## Locally (with a virtualenv)
+## Virtualenv
 
     virtualenv venv
     venv/bin/python initial_setup.py --venv
+
+The initial setup script guides you through the rest of the process.
 
 ## Docker
 
@@ -124,19 +123,3 @@ start the named container like so:
 and
 
     docker start wasa2il-dev-container
-
-
-# Running locally
-
-In order to run wasa2il locally for development purposes you need run
-`manage.py runserver`.  If you installed the wasa2il dependencies globally
-(not in a virtualenv), you should be able to run:
-
-    cd wasa2il && python ./manage.py runserver
-
-from the repository root.
-
-If you installed the dependencies in a virtualenv, you need to run the app
-via the python there, or source the activate script:
-
-    cd wasa2il && ../venv/bin/python ./manage.py runserver

--- a/initial_setup.py
+++ b/initial_setup.py
@@ -16,12 +16,11 @@ random = random.SystemRandom()
 
 TERMINAL_WIDTH = 80
 
-venv_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'venv/bin')
+venv_path = os.path.normpath('venv/bin')
 
 
 def get_executable_path(executable):
     if len(argv) > 1 and argv[1] == '--venv':
-        print os.path.join(venv_path, executable)
         return os.path.join(venv_path, executable)
     return executable
 
@@ -137,9 +136,9 @@ if not local_settings_changed:
     stdout.write('- No changes needed.\n')
 
 # Compile the translation files
-for lang in next(os.walk(os.path.join(os.getcwd(), 'locale')))[1]:
-    print [get_executable_path('pybabel'), 'compile', '-d', os.path.join(os.getcwd(), 'locale'), '-D', 'django', '-l', lang]
-    subprocess.call([get_executable_path('pybabel'), 'compile', '-d', os.path.join(os.getcwd(), 'locale'), '-D', 'django', '-l', lang])
+for lang in next(os.walk(os.path.join(os.getcwd(), 'wasa2il/locale')))[1]:
+    print [get_executable_path('pybabel'), 'compile', '-d', os.path.join(os.getcwd(), 'wasa2il/locale'), '-D', 'django', '-l', lang]
+    subprocess.call([get_executable_path('pybabel'), 'compile', '-d', os.path.join(os.getcwd(), 'wasa2il/locale'), '-D', 'django', '-l', lang])
 
 
 # Setup database if needed
@@ -169,12 +168,12 @@ if create_database:
 print "*" * TERMINAL_WIDTH
 print "All done!"
 print "To run Wasa2il and start configuring polities, follow these steps:"
-print "- Go to the 'wasa2il' directory and run 'python manage.py runserver'"
+print "- Run '"+get_executable_path('python')+" manage.py runserver'"
 print "- Open your favorite browser and type in: http://localhost:8000"
 print "- Log in with the superuser account created previously"
 print
-print "(If you don't have a superuser account yet, then go to the 'wasa2il' directory"
-print "and run 'python manage.py createsuperuser')"
+print "Additional superuser accounts can be created with"
+print "- "+get_executable_path('python')+" manage.py createsuperuser"
 print "*" * TERMINAL_WIDTH
 
 

--- a/initial_setup.py
+++ b/initial_setup.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import fileinput
 import shutil
+import sys
 
 from sys import stderr
 from sys import stdin
@@ -15,9 +16,7 @@ import random
 random = random.SystemRandom()
 
 TERMINAL_WIDTH = 80
-
-venv_path = os.path.normpath('venv/bin')
-
+venv_path = os.path.relpath(os.path.dirname(sys.executable), sys.path[0])
 
 def get_executable_path(executable):
     if len(argv) > 1 and argv[1] == '--venv':


### PR DESCRIPTION
- initial_setup.py:
  - Fix locale->wasa2il/locale path change
  - Correct instructions when running in virtualenv (python path)

- Deduplicate instruction in README.md, some of it was covered in initial_setup.py