### PR TITLE
UI: Move 'new issues' to the top. Closes #47

### DIFF
--- a/wasa2il/templates/core/polity_detail.html
+++ b/wasa2il/templates/core/polity_detail.html
@@ -27,6 +27,45 @@
 
 
 <div class="row">
+    <div class="col-md-6 col-xs-12"><a name="newissues"></a>
+
+        <div class="btn-group" role="group" style="float: right">
+            <a class="btn btn-default btn-sm dropdown-toggle" role="button" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-list"></span><span class="caret"></span></a>
+            <ul class="dropdown-menu" style="left: -50px;">
+                <li><a href="{% url 'polity_issues_new' polity.id %}">{% trans "Show all new issues" %}</a></li>
+            </ul>
+        </div>
+
+        <h2>{% trans "New issues" %} <small>{% trans "in discussion"%}</small></h2>
+
+        <p class="muted">{% trans "These are the newest issues being discussed in this polity." %}</p>
+
+        <table class="table table-striped table-bordered table-condensed" id="newissues_list">
+        <thead>
+        <tr>
+            <th>{% trans "Issue" %}</th>
+            <th>{% trans "State" %}</th>
+            <th>{% trans "Comments" %}</th>
+            <th>{% trans "Votes" %}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for issue in newissues %}
+            <tr>
+                <td>
+                    <span id="issuestar_{{ issue.id }}" class="glyphicon glyphicon-pencil {% if issue|issuevoted:user %}{% else %}icon-grey{% endif %}"
+                        title="{% if issue|issuevoted:user %}{% trans "You have voted on this issue" %}{% else %}{% trans "You have not voted on this issue" %}{% endif %}"></span>
+                    <a href="/issue/{{issue.id}}/">{{issue.name}}</a>
+                </td>
+                <td class="issue-status">{% if issue.is_voting %}{% trans "Voting" %}{% else %}{% if issue.is_open %}{% trans "Open" %}{% else %}{% trans "New" %}{% endif %}{% endif %}</td>
+                <td>{{ issue.comment_set.count }}</td>
+                <td>{{ issue.get_votes.count }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        </table>
+    </div>
+
     <div class="col-md-6 col-xs-12"><a name="topics"></a>
         {% if user_is_member %}
         <div class="btn-group" style="float: right">
@@ -74,45 +113,6 @@
         {% with polity.agreements as documentcontents %}
             {% include "core/_document_agreement_list_table.html" %}
         {% endwith %}
-    </div>
-
-    <div class="col-md-6 col-xs-12"><a name="newissues"></a>
-
-        <div class="btn-group" role="group" style="float: right">
-            <a class="btn btn-default btn-sm dropdown-toggle" role="button" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-list"></span><span class="caret"></span></a>
-            <ul class="dropdown-menu" style="left: -50px;">
-                <li><a href="{% url 'polity_issues_new' polity.id %}">{% trans "Show all new issues" %}</a></li>
-            </ul>
-        </div>
-
-        <h2>{% trans "New issues" %} <small>{% trans "in discussion"%}</small></h2>
-
-        <p class="muted">{% trans "These are the newest issues being discussed in this polity." %}</p>
-
-        <table class="table table-striped table-bordered table-condensed" id="newissues_list">
-        <thead>
-        <tr>
-            <th>{% trans "Issue" %}</th>
-            <th>{% trans "State" %}</th>
-            <th>{% trans "Comments" %}</th>
-            <th>{% trans "Votes" %}</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for issue in newissues %}
-            <tr>
-                <td>
-                    <span id="issuestar_{{ issue.id }}" class="glyphicon glyphicon-pencil {% if issue|issuevoted:user %}{% else %}icon-grey{% endif %}"
-                        title="{% if issue|issuevoted:user %}{% trans "You have voted on this issue" %}{% else %}{% trans "You have not voted on this issue" %}{% endif %}"></span>
-                    <a href="/issue/{{issue.id}}/">{{issue.name}}</a>
-                </td>
-                <td class="issue-status">{% if issue.is_voting %}{% trans "Voting" %}{% else %}{% if issue.is_open %}{% trans "Open" %}{% else %}{% trans "New" %}{% endif %}{% endif %}</td>
-                <td>{{ issue.comment_set.count }}</td>
-                <td>{{ issue.get_votes.count }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-        </table>
     </div>
 
     <div class="col-md-6 col-xs-12">

--- a/wasa2il/templates/core/polity_detail.html
+++ b/wasa2il/templates/core/polity_detail.html
@@ -66,6 +66,21 @@
         </table>
     </div>
 
+    <div class="col-md-6 col-xs-12" style="float: right;"><a name="documents"></a>
+        {% if user_is_member %}
+        <div class="btn-group" style="float: right">
+            <a class="btn btn-default btn-sm" role="button" href="/polity/{{ polity.id }}/document/new/">{% trans "New document" %}</a>
+        </div>
+        {% endif %}
+        <h2>{% trans "Agreements" %} <small>{% trans "of this polity" %}</small></h2>
+
+        <p class="muted">{% trans "Here are all of the agreements this polity has arrived at." %}</p>
+
+        {% with polity.agreements as documentcontents %}
+            {% include "core/_document_agreement_list_table.html" %}
+        {% endwith %}
+    </div>
+
     <div class="col-md-6 col-xs-12"><a name="topics"></a>
         {% if user_is_member %}
         <div class="btn-group" style="float: right">
@@ -98,21 +113,6 @@
         {% endwith %}
         </tbody>
         </table>
-    </div>
-
-    <div class="col-md-6 col-xs-12" style="float: right;"><a name="documents"></a>
-        {% if user_is_member %}
-        <div class="btn-group" style="float: right">
-            <a class="btn btn-default btn-sm" role="button" href="/polity/{{ polity.id }}/document/new/">{% trans "New document" %}</a>
-        </div>
-        {% endif %}
-        <h2>{% trans "Agreements" %} <small>{% trans "of this polity" %}</small></h2>
-
-        <p class="muted">{% trans "Here are all of the agreements this polity has arrived at." %}</p>
-
-        {% with polity.agreements as documentcontents %}
-            {% include "core/_document_agreement_list_table.html" %}
-        {% endwith %}
     </div>
 
     <div class="col-md-6 col-xs-12">


### PR DESCRIPTION
This is what I use 99% of the time and when on mobile, I need to scroll endlessly down to see new issues.

Therefore I suggest 'New issues' should be moved to the top for increased user happiness!