### PR TITLE
UI: minor cleanup on polity page

### DIFF
--- a/wasa2il/templates/core/polity_detail.html
+++ b/wasa2il/templates/core/polity_detail.html
@@ -4,7 +4,7 @@
 {% block content %}
 
 {% if user_is_member %}
-    <div style="float:right;" class="memberstatusbox">
+    <div class="memberstatusbox">
         {% if user in polity.officers.all %}
             {% trans "You are an officer in this polity." %}
         {% else %}
@@ -17,15 +17,14 @@
 
 {% if user_is_member or polity.is_nonmembers_readable %}
 
-<div id="polity_stats" class="subnav">
-    <ul class="nav nav-pills">
-        <li><a href="#topics">{{polity.topic_set.count}} {% trans "topics" %}</a></li>
-        <li><a href="#documents">{{polity.agreements.count}} {% trans "agreements" %}</a></li>
-        <li><a href="#subpolities" onclick="$('#modal_subpolities').modal('show');">{{polity.polity_set.count}} {% trans "subpolities" %}</a></li>
-    </ul>
+<div id="polity_stats">
+    <div class="btn-group" role="group">
+        <a href="#newissues" type="button" class="btn btn-default">{{newissues.count}} {% trans "New issues" %}</a>
+        <a href="#documents" type="button" class="btn btn-default">{{polity.agreements.count}} {% trans "Agreements" %}<a>
+        <a href="#topics" type="button" class="btn btn-default">{{polity.topic_set.count}} {% trans "Topics" %}</a>
+    </div>
 </div>
-
-
+<hr>
 <div class="row">
     <div class="col-md-6 col-xs-12"><a name="newissues"></a>
 

--- a/wasa2il/templates/core/polity_detail.html
+++ b/wasa2il/templates/core/polity_detail.html
@@ -27,6 +27,45 @@
 
 
 <div class="row">
+    <div class="col-md-6 col-xs-12"><a name="newissues"></a>
+
+        <div class="btn-group" role="group" style="float: right">
+            <a class="btn btn-default btn-sm dropdown-toggle" role="button" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-list"></span><span class="caret"></span></a>
+            <ul class="dropdown-menu" style="left: -50px;">
+                <li><a href="{% url 'polity_issues_new' polity.id %}">{% trans "Show all new issues" %}</a></li>
+            </ul>
+        </div>
+
+        <h2>{% trans "New issues" %} <small>{% trans "in discussion"%}</small></h2>
+
+        <p class="muted">{% trans "These are the newest issues being discussed in this polity." %}</p>
+
+        <table class="table table-striped table-bordered table-condensed" id="newissues_list">
+        <thead>
+        <tr>
+            <th>{% trans "Issue" %}</th>
+            <th>{% trans "State" %}</th>
+            <th>{% trans "Comments" %}</th>
+            <th>{% trans "Votes" %}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for issue in newissues %}
+            <tr>
+                <td>
+                    <span id="issuestar_{{ issue.id }}" class="glyphicon glyphicon-pencil {% if issue|issuevoted:user %}{% else %}icon-grey{% endif %}"
+                        title="{% if issue|issuevoted:user %}{% trans "You have voted on this issue" %}{% else %}{% trans "You have not voted on this issue" %}{% endif %}"></span>
+                    <a href="/issue/{{issue.id}}/">{{issue.name}}</a>
+                </td>
+                <td class="issue-status">{% if issue.is_voting %}{% trans "Voting" %}{% else %}{% if issue.is_open %}{% trans "Open" %}{% else %}{% trans "New" %}{% endif %}{% endif %}</td>
+                <td>{{ issue.comment_set.count }}</td>
+                <td>{{ issue.get_votes.count }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        </table>
+    </div>
+
     <div class="col-md-6 col-xs-12"><a name="topics"></a>
         {% if user_is_member %}
         <div class="btn-group" style="float: right">
@@ -74,45 +113,6 @@
         {% with polity.agreements as documentcontents %}
             {% include "core/_document_agreement_list_table.html" %}
         {% endwith %}
-    </div>
-
-    <div class="col-md-6 col-xs-12"><a name="newissues"></a>
-
-        <div class="btn-group" role="group" style="float: right">
-            <a class="btn btn-default btn-sm dropdown-toggle" role="button" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-list"></span><span class="caret"></span></a>
-            <ul class="dropdown-menu" style="left: -50px;">
-                <li><a href="{% url 'polity_issues_new' polity.id %}">{% trans "Show all new issues" %}</a></li>
-            </ul>
-        </div>
-
-        <h2>{% trans "New issues" %} <small>{% trans "in discussion"%}</small></h2>
-
-        <p class="muted">{% trans "These are the newest issues being discussed in this polity." %}</p>
-
-        <table class="table table-striped table-bordered table-condensed" id="newissues_list">
-        <thead>
-        <tr>
-            <th>{% trans "Issue" %}</th>
-            <th>{% trans "State" %}</th>
-            <th>{% trans "Comments" %}</th>
-            <th>{% trans "Votes" %}</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for issue in newissues %}
-            <tr>
-                <td>
-                    <span id="issuestar_{{ issue.id }}" class="glyphicon glyphicon-pencil {% if issue|issuevoted:user %}{% else %}icon-grey{% endif %}"
-                        title="{% if issue|issuevoted:user %}{% trans "You have voted on this issue" %}{% else %}{% trans "You have not voted on this issue" %}{% endif %}"></span>
-                    <a href="/issue/{{issue.id}}/">{{issue.name}}</a>
-                </td>
-                <td class="issue-status">{% if issue.is_voting %}{% trans "Voting" %}{% else %}{% if issue.is_open %}{% trans "Open" %}{% else %}{% trans "New" %}{% endif %}{% endif %}</td>
-                <td>{{ issue.comment_set.count }}</td>
-                <td>{{ issue.get_votes.count }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-        </table>
     </div>
 
     <div class="col-md-6 col-xs-12">

--- a/wasa2il/templates/core/polity_detail.html
+++ b/wasa2il/templates/core/polity_detail.html
@@ -66,6 +66,21 @@
         </table>
     </div>
 
+    <div class="col-md-6 col-xs-12" style="float: right;"><a name="documents"></a>
+        {% if user_is_member %}
+        <div class="btn-group" style="float: right">
+            <a class="btn btn-default btn-sm" role="button" href="/polity/{{ polity.id }}/document/new/">{% trans "New document" %}</a>
+        </div>
+        {% endif %}
+        <h2>{% trans "Agreements" %} <small>{% trans "of this polity" %}</small></h2>
+
+        <p class="muted">{% trans "Here are all of the agreements this polity has arrived at." %}</p>
+
+        {% with polity.agreements as documentcontents %}
+            {% include "core/_document_agreement_list_table.html" %}
+        {% endwith %}
+    </div>
+
     <div class="col-md-6 col-xs-12"><a name="topics"></a>
         {% if user_is_member %}
         <div class="btn-group" style="float: right">
@@ -98,21 +113,6 @@
         {% endwith %}
         </tbody>
         </table>
-    </div>
-
-    <div class="col-md-6 col-xs-12" style="float: right;"><a name="documents"></a>
-        {% if user_is_member %}
-        <div class="btn-group" style="float: right">
-            <a class="btn btn-default btn-sm" role="button" href="/polity/{{ polity.id }}/document/new/">{% trans "New document" %}</a>
-        </div>
-        {% endif %}
-        <h2>{% trans "Agreements" %} <small>{% trans "of this polity" %}</small></h2>
-
-        <p class="muted">{% trans "Here are all of the agreements this polity has arrived at." %}</p>
-
-        {% with polity.agreements as documentcontents %}
-            {% include "core/_document_agreement_list_table.html" %}
-        {% endwith %}
     </div>
 
     <div class="col-md-6 col-xs-12">


### PR DESCRIPTION
1. The Subpolity button did not fit in with the other buttons purpose wise so I removed it.
Now these 3 buttons have one purpose, to jump to each section respectively.
(If we need to access the subpolities, we just click the Pirate logo and go to the front page).
@helgihg mentioned we should create a tree for that and I think we should do that on the front page.
If we do it in a modal (which the removed button did), it will be nasty when the tree grows large.

2. Make memberstatusbox not float right, it broke longer policy names.

3. Instead of the purple nav-pills, use buttons to emphasize their clickability.

===

**Before:**

![2016-05-29_449x354](https://cloud.githubusercontent.com/assets/1689020/15635251/0ad583aa-25da-11e6-9fee-16e516185eff.png)

===
**After:**
![2016-05-29_388x278](https://cloud.githubusercontent.com/assets/1689020/15635245/cf9c5048-25d9-11e6-9958-c6b422ec89be.png)