### PR TITLE
Add voting stats to agreements list on polity page

### DIFF
--- a/core/static/css/application.css
+++ b/core/static/css/application.css
@@ -358,6 +358,16 @@ ul.errorlist {
 .glyphicon { cursor: pointer; }
 .dropdown-menu { cursor: pointer; }
 
+.red {
+  color: red;
+}
+.green {
+  color: green;
+}
+.grey {
+  color: grey;
+}
+
 @media (max-width:767px){
   .piratepurple {
     background-color:#62388d;

--- a/wasa2il/templates/core/_document_agreement_list_table.html
+++ b/wasa2il/templates/core/_document_agreement_list_table.html
@@ -2,11 +2,23 @@
 <table class="table table-striped table-bordered table-condensed">
 <tr>
     <th>{% trans "Document" %}</th>
+    <th>{% trans "Yes" %} </th>
+    <th>{% trans "No" %} </th>
+    <th>{% trans "Abstain" %} </th>
     <th class="right">{% trans "Adopted" %}</th>
 </tr>
 {% for documentcontent in documentcontents %}
 <tr>
     <td><a href="/polity/{{ polity.id }}/document/{{ documentcontent.document.id }}/">{{ documentcontent.document.name }}</a></td>
+    <td class="col-md-1 green">
+      {{ documentcontent.issue.get_votes.yes }}
+    </td>
+    <td class="col-md-1 red">
+      {{ documentcontent.issue.get_votes.no }}
+    </td>
+    <td class="col-md-1 grey">
+      {{ documentcontent.issue.get_votes.abstain }}
+    </td>
     <td class="date">{{ documentcontent.issue.deadline_votes|date }}</td>
 </tr>
 {% empty %}


### PR DESCRIPTION
It was hard to find the statistics, you had to click the document, then the referenced issue.

Now the stats are available at the polity page:

![2016-06-03_592x327](https://cloud.githubusercontent.com/assets/1689020/15789629/8f15c00c-29cd-11e6-8c48-60299e13291a.png)

NOTE:
Since I did not have any reliable dummy data, this might now work on some edge cases, who knows?