### PR TITLE
UI: clean up users profile, picture was huge,fixed

### DIFF
--- a/wasa2il/templates/profile.html
+++ b/wasa2il/templates/profile.html
@@ -23,13 +23,15 @@
         </ul>
         <div class="tab-content">
             <div class="tab-pane active" id="summary">
-                <div class="row-fluid">
-                    <div class="span9">
+                <div class="row">
+                    <div class="col-md-4">
                         {% if profile.picture %}
-                            <img class="img-polaroid" src="{{ profile.picture.url }}" />
+                            <img class="img-thumbnail" src="{{ profile.picture.url }}" />
                         {% else %}
-                            <img class="img-polaroid" src="http://placekitten.com/g/200/300" />
+                            <img class="img-thumbnail" src="http://placekitten.com/g/200/300" />
                         {% endif %}
+                    </div>
+                     <div class="col-md-8">
                         <div id="user-bio">
                             {% if profile.bio %}
                                 {{profile.bio|linebreaksbr}}
@@ -38,7 +40,7 @@
                             {% endif %}
                         </div>
                     </div>
-                </div>
+                </div> <!-- ./row -->
             </div>
             {% for polity in polities %}
                 <div class="tab-pane" id="polity{{ polity.id }}">


### PR DESCRIPTION
Minor cleanup on users profile page, picture was huge and out of line with other elements.

Now using bootstrap columns.

![2016-06-16_1167x504](https://cloud.githubusercontent.com/assets/1689020/16130184/4c5b615a-3408-11e6-892b-1d50ced59fd7.png)

**Mobile:**

![2016-06-16_394x632](https://cloud.githubusercontent.com/assets/1689020/16130220/769e649e-3408-11e6-9c61-4c5a236eb432.png)
