### PR TITLE
UI: Add profile pic next to comment new discussion

### DIFF
--- a/wasa2il/templates/core/topic_detail.html
+++ b/wasa2il/templates/core/topic_detail.html
@@ -44,6 +44,7 @@
         {% for comment in topic.new_comments %}
         <div class="comment" id="comment_{{comment.id}}">
             <div class="comment_created_by">
+                <a href="/accounts/profile/{{comment.created_by}}/"><img class="" src="{{ comment.created_by.userprofile.picture |thumbnail:'40x40' }}" /></a>
                 <a href="/accounts/profile/{{comment.created_by}}/">{{comment.created_by}}</a>
                 {% trans "in" %} <a href="/issue/{{comment.issue.id}}/">{{comment.issue.name}}</a>
             </div>


### PR DESCRIPTION
This is only on the 'new discussions', not the actual 'issues discussion'. 

We can try this for now and see if it works.

![2016-06-16_797x440](https://cloud.githubusercontent.com/assets/1689020/16133747/caffd9d0-3419-11e6-8b03-69ec108bf8ae.png)
