### PR TITLE
UI: adding shortcut button for elections

### DIFF
--- a/wasa2il/templates/core/polity_detail.html
+++ b/wasa2il/templates/core/polity_detail.html
@@ -21,7 +21,8 @@
     <div class="btn-group" role="group">
         <a href="#newissues" type="button" class="btn btn-default">{{newissues.count}} {% trans "New issues" %}</a>
         <a href="#documents" type="button" class="btn btn-default">{{polity.agreements.count}} {% trans "Agreements" %}<a>
-        <a href="#topics" type="button" class="btn btn-default">{{polity.topic_set.count}} {% trans "Topics" %}</a>
+        <a href="#topics"    type="button" class="btn btn-default">{{polity.topic_set.count}} {% trans "Topics" %}</a>
+        <a href="#elections" type="button" class="btn btn-default">{{newelections.count}} {% trans "Elections" %}</a>
     </div>
 </div>
 <hr>
@@ -114,7 +115,7 @@
         </table>
     </div>
 
-    <div class="col-md-6 col-xs-12">
+    <div class="col-md-6 col-xs-12"><a name="elections">
         <div class="btn-group" role="group" style="float: right">
             {% if user_is_member %}
                 {% if not polity.is_newissue_only_officers or polity.is_newissue_only_officers and user in polity.officers.all %}


### PR DESCRIPTION
We were missing a shortcut nav button for elections. 
Now we have the 4 categories:

![2016-06-19_518x152](https://cloud.githubusercontent.com/assets/1689020/16177044/0018b8f8-3622-11e6-93f6-fa0504e700d4.png)
