### PR TITLE
#121 Make sure generated thumbnails have requested resolution

### DIFF
--- a/core/templatetags/wasa2il.py
+++ b/core/templatetags/wasa2il.py
@@ -1,8 +1,8 @@
-
 import os
 import markdown2
 
 from PIL import Image
+from pilkit.processors import SmartResize
 
 from django import template
 from django.template.defaultfilters import stringfilter
@@ -64,7 +64,8 @@ def thumbnail(file, size='104x104'):
         # if the image wasn't already resized, resize it
         if not os.path.exists(miniature_filename):
             image = Image.open(filename)
-            image.thumbnail([x, y], Image.ANTIALIAS)
+            processor = SmartResize(width=x, height=y)
+            image = processor.process(image)
             try:
                 image.save(miniature_filename, image.format, quality=90, optimize=1)
             except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ ipython==2.3.0
 lxml==3.6.0
 markdown2==2.3.0
 MySQL-python==1.2.5
+pilkit==1.1.13
 Pillow==3.0.0
 pyasn1==0.1.9
 pycparser==2.14


### PR DESCRIPTION
WIP since the results are not as good as smartcrop.js, there is a bit of
empty space on the left side while smartcrop.js images are more symmetric. The algorithm might need to be rebased on latest smartcrop.js or parameters adjusted.
