### PR TITLE
WIP: Add vote buttons which move cand to top, bottom

### DIFF
--- a/core/static/css/application.css
+++ b/core/static/css/application.css
@@ -98,7 +98,7 @@ textarea {
 }
 
 #vote {
-  padding-left: 20px;
+  padding-left: 7px;
 }
 
 #votes li {

--- a/core/static/css/application.css
+++ b/core/static/css/application.css
@@ -76,25 +76,20 @@ textarea {
 	font-size:			15pt;
 }
 
-.candidates li div {
-	display:			block;
-}
-
 .candidates li div:hover {
 	text-decoration:		none;
-}
-
-#candidates li {
-	display:			block;
 }
 
 #candidates {
   padding-left: 0px;
 }
 
-.vote-button {
-    float: right;
-    margin-top: 12px;
+#election_candidates ul{
+  list-style-type: none;
+}
+
+.vote-yes {
+   float: right;
 }
 
 .vote-image {

--- a/core/static/css/application.css
+++ b/core/static/css/application.css
@@ -60,20 +60,15 @@ textarea {
 	counter-reset: 			statement-counter -1;
 }
 
-.candidates {
-	min-height:			50px;
-}
-
 .candidates p {
 	padding:			10px;
 	border:				1px solid #ddd;
 }
 
 .candidates li {
-	border-bottom:		1px solid #ddd;
-	padding-bottom:		3px;
-	padding-top:      3px;
-	font-size:			15pt;
+	border-top:		1px solid #ddd;
+	padding:      5px;
+	font-size:    15px;
 }
 
 .candidates li div:hover {
@@ -110,6 +105,14 @@ textarea {
 	display:			list-item;
 }
 
+.vote-tip{
+  font-size: 15px;
+  padding: 15px 5px;
+  border-bottom: 1px solid #ccc;
+}
+
+.frozen {
+}
 
 .memberstatusbox {
 	padding:			5px;

--- a/wasa2il/locale/is/LC_MESSAGES/django.po
+++ b/wasa2il/locale/is/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wasa2il\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-30 16:24+0000\n"
+"POT-Creation-Date: 2016-08-06 16:48+0000\n"
 "PO-Revision-Date: 2013-01-31 22:03+0100\n"
 "Last-Translator: smari <smari@immi.is>\n"
 "Language-Team: Icelandic\n"
@@ -13,11 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: crowdin.net\n"
 
-#: core/authentication.py:20 core/forms.py:46
+#: core/authentication.py:57 core/forms.py:46
 msgid "E-mail"
 msgstr "Netfang"
 
-#: core/authentication.py:21
+#: core/authentication.py:58
 msgid "Password"
 msgstr "Lykilorð"
 
@@ -67,32 +67,32 @@ msgstr "Tungumál"
 msgid "Whether to show all topics in a polity, or only starred."
 msgstr "Hvort eigi að sýna mál þings, eða einungis stjörnumerkt."
 
-#: core/models.py:154
+#: core/models.py:161
 msgid "Officers"
 msgstr "Umsjónarmenn"
 
-#: core/models.py:157
+#: core/models.py:163
 msgid "Publicly listed?"
 msgstr "Listað opinberlega?"
 
-#: core/models.py:157
+#: core/models.py:163
 msgid "Whether the polity is publicly listed or not."
 msgstr "Hvort þingið sé listað opinberlega eður ei."
 
-#: core/models.py:158
+#: core/models.py:164
 msgid "Publicly viewable?"
 msgstr "Sýnilegt opinberlega?"
 
-#: core/models.py:158
+#: core/models.py:164
 msgid "Whether non-members can view the polity and its activities."
 msgstr ""
 "Hvort notendur sem ekki eru meðlimir þingsins geti séð það og innihald þess."
 
-#: core/models.py:159
+#: core/models.py:165
 msgid "Can only officers make new issues?"
 msgstr "Geta einungis umsjónarmenn búið til ný mál?"
 
-#: core/models.py:159
+#: core/models.py:165
 msgid ""
 "If this is checked, only officers can create new issues. If it's unchecked, "
 "any member can start a new issue."
@@ -100,11 +100,11 @@ msgstr ""
 "Ef þetta er valið geta einungis umsjónarmenn búið til ný mál. Ellegar geta "
 "allir meðlimir búið til ný mál."
 
-#: core/models.py:160
+#: core/models.py:166
 msgid "Front polity?"
 msgstr "Aðalþing?"
 
-#: core/models.py:160
+#: core/models.py:166
 msgid ""
 "If checked, this polity will be displayed on the front page. The first "
 "created polity automatically becomes the front polity."
@@ -112,168 +112,168 @@ msgstr ""
 "Ef hakað er við þetta verður þetta þing sýnt á forsíðunni. Fyrsta þingið sem "
 "búið er til verður sjálfkrafa að aðalþingi."
 
-#: core/models.py:288
+#: core/models.py:294
 msgid "Accepted at assembly"
 msgstr "Samþykkt á samkomu"
 
-#: core/models.py:289
+#: core/models.py:295
 msgid "Rejected at assembly"
 msgstr "Hafnað á samkomu"
 
-#: core/models.py:298 wasa2il/templates/core/polity_detail.html:24
-#: wasa2il/templates/core/polity_detail.html:96
-#: wasa2il/templates/core/polity_detail.html:103
+#: core/models.py:304 wasa2il/templates/core/polity_detail.html:24
+#: wasa2il/templates/core/polity_detail.html:107
+#: wasa2il/templates/core/polity_detail.html:114
 #: wasa2il/templates/core/polity_list.html:17
 msgid "Topics"
 msgstr "Málaflokkar"
 
-#: core/models.py:304
+#: core/models.py:310
 msgid "Ruleset"
 msgstr "Reglur"
 
-#: core/models.py:306 wasa2il/templates/core/issue_detail.html:39
+#: core/models.py:312 wasa2il/templates/core/issue_detail.html:39
 msgid "Special process"
 msgstr "Sérstakur ferill"
 
-#: core/models.py:495 wasa2il/templates/core/issues_new.html:18
-#: wasa2il/templates/core/polity_detail.html:46
+#: core/models.py:501 wasa2il/templates/core/issues_new.html:18
+#: wasa2il/templates/core/polity_detail.html:47
 msgid "Issue"
 msgstr "Málefni"
 
-#: core/models.py:500
+#: core/models.py:506
 msgid "Topic"
 msgstr "Málaflokkur"
 
-#: core/models.py:505 wasa2il/templates/core/polity_list.html:16
+#: core/models.py:511 wasa2il/templates/core/polity_list.html:16
 msgid "Polity"
 msgstr "Þing"
 
-#: core/models.py:644
+#: core/models.py:650
 msgid "Proposed"
 msgstr "Tillaga"
 
-#: core/models.py:645 wasa2il/templates/core/issue_detail.html:49
+#: core/models.py:651 wasa2il/templates/core/issue_detail.html:49
 msgid "Accepted"
 msgstr "Samþykkt"
 
-#: core/models.py:646 wasa2il/templates/core/issue_detail.html:49
+#: core/models.py:652 wasa2il/templates/core/issue_detail.html:49
 msgid "Rejected"
 msgstr "Hafnað"
 
-#: core/models.py:647
+#: core/models.py:653
 msgid "Deprecated"
 msgstr "Úrelt"
 
-#: core/models.py:785 wasa2il/templates/core/election_detail.html:82
+#: core/models.py:791 wasa2il/templates/core/election_detail.html:93
 msgid "Voting system"
 msgstr "Kosningakerfi"
 
-#: core/models.py:786 wasa2il/templates/core/election_detail.html:72
+#: core/models.py:792 wasa2il/templates/core/election_detail.html:74
 #: wasa2il/templates/core/election_list.html:19
 msgid "Deadline for candidacy"
 msgstr "Tímamörk fyrir framboð"
 
-#: core/models.py:787
+#: core/models.py:793
 msgid "Start time for votes"
 msgstr "Upphaf kosninga"
 
-#: core/models.py:788 wasa2il/templates/core/election_detail.html:73
+#: core/models.py:794 wasa2il/templates/core/election_detail.html:75
 #: wasa2il/templates/core/election_list.html:20
 #: wasa2il/templates/core/issue_detail.html:36
 msgid "Deadline for votes"
 msgstr "Tímamörk fyrir atkvæði"
 
-#: core/models.py:799
+#: core/models.py:805 wasa2il/templates/core/election_detail.html:77
 msgid "Membership deadline"
 msgstr "Skráningarmörk kjósenda"
 
-#: core/models.py:802 wasa2il/templates/base.html:128
+#: core/models.py:808 wasa2il/templates/base.html:142
 msgid "Instructions"
 msgstr "Leiðbeiningar"
 
-#: core/views.py:417
+#: core/views.py:418
 msgid "voting"
 msgstr "atkvæðagreiðsla"
 
-#: local/env/lib/python2.7/site-packages/django/contrib/messages/apps.py:7
+#: venv/lib/python2.7/site-packages/django/contrib/messages/apps.py:7
 #: wasa2il/templates/forum/forum_detail.html:19
 msgid "Messages"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/contrib/sitemaps/apps.py:7
+#: venv/lib/python2.7/site-packages/django/contrib/sitemaps/apps.py:7
 msgid "Site Maps"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/contrib/staticfiles/apps.py:7
+#: venv/lib/python2.7/site-packages/django/contrib/staticfiles/apps.py:7
 msgid "Static Files"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/contrib/syndication/apps.py:7
+#: venv/lib/python2.7/site-packages/django/contrib/syndication/apps.py:7
 msgid "Syndication"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/contrib/webdesign/apps.py:7
+#: venv/lib/python2.7/site-packages/django/contrib/webdesign/apps.py:7
 msgid "Web Design"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:20
+#: venv/lib/python2.7/site-packages/django/core/validators.py:20
 msgid "Enter a valid value."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:94
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:712
+#: venv/lib/python2.7/site-packages/django/core/validators.py:94
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:712
 msgid "Enter a valid URL."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:137
+#: venv/lib/python2.7/site-packages/django/core/validators.py:137
 msgid "Enter a valid integer."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:148
+#: venv/lib/python2.7/site-packages/django/core/validators.py:148
 msgid "Enter a valid email address."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:222
+#: venv/lib/python2.7/site-packages/django/core/validators.py:222
 msgid ""
 "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:227
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:246
+#: venv/lib/python2.7/site-packages/django/core/validators.py:227
+#: venv/lib/python2.7/site-packages/django/core/validators.py:246
 msgid "Enter a valid IPv4 address."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:232
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:247
+#: venv/lib/python2.7/site-packages/django/core/validators.py:232
+#: venv/lib/python2.7/site-packages/django/core/validators.py:247
 msgid "Enter a valid IPv6 address."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:242
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:245
+#: venv/lib/python2.7/site-packages/django/core/validators.py:242
+#: venv/lib/python2.7/site-packages/django/core/validators.py:245
 msgid "Enter a valid IPv4 or IPv6 address."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:270
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1144
+#: venv/lib/python2.7/site-packages/django/core/validators.py:270
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1144
 msgid "Enter only digits separated by commas."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:279
+#: venv/lib/python2.7/site-packages/django/core/validators.py:279
 #, python-format
 msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:305
+#: venv/lib/python2.7/site-packages/django/core/validators.py:305
 #, python-format
 msgid "Ensure this value is less than or equal to %(limit_value)s."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:312
+#: venv/lib/python2.7/site-packages/django/core/validators.py:312
 #, python-format
 msgid "Ensure this value is greater than or equal to %(limit_value)s."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:321
+#: venv/lib/python2.7/site-packages/django/core/validators.py:321
 #, python-format
 msgid ""
 "Ensure this value has at least %(limit_value)d character (it has "
@@ -284,7 +284,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/core/validators.py:332
+#: venv/lib/python2.7/site-packages/django/core/validators.py:332
 #, python-format
 msgid ""
 "Ensure this value has at most %(limit_value)d character (it has "
@@ -295,277 +295,277 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/base.py:1130
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:718
+#: venv/lib/python2.7/site-packages/django/db/models/base.py:1130
+#: venv/lib/python2.7/site-packages/django/forms/models.py:718
 msgid "and"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/base.py:1132
+#: venv/lib/python2.7/site-packages/django/db/models/base.py:1132
 #, python-format
 msgid "%(model_name)s with this %(field_labels)s already exists."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:107
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:107
 #, python-format
 msgid "Value %(value)r is not a valid choice."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:108
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:108
 msgid "This field cannot be null."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:109
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:109
 msgid "This field cannot be blank."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:110
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:110
 #, python-format
 msgid "%(model_name)s with this %(field_label)s already exists."
 msgstr ""
 
 #. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
 #. Eg: "Title must be unique for pub_date year"
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:114
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:114
 #, python-format
 msgid ""
 "%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:132
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:132
 #, python-format
 msgid "Field of type: %(field_type)s"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:922
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1832
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:922
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1832
 msgid "Integer"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:926
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1830
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:926
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1830
 #, python-format
 msgid "'%(value)s' value must be an integer."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1001
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1001
 #, python-format
 msgid "'%(value)s' value must be either True or False."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1003
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1003
 msgid "Boolean (Either True or False)"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1078
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1078
 #, python-format
 msgid "String (up to %(max_length)s)"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1139
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1139
 msgid "Comma-separated integers"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1188
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1188
 #, python-format
 msgid ""
 "'%(value)s' value has an invalid date format. It must be in YYYY-MM-DD "
 "format."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1190
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1340
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1190
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1340
 #, python-format
 msgid ""
 "'%(value)s' value has the correct format (YYYY-MM-DD) but it is an invalid "
 "date."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1193
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1193
 msgid "Date (without time)"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1338
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1338
 #, python-format
 msgid ""
 "'%(value)s' value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
 "uuuuuu]][TZ] format."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1342
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1342
 #, python-format
 msgid ""
 "'%(value)s' value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
 "[TZ]) but it is an invalid date/time."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1346
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1346
 msgid "Date (with time)"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1498
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1498
 #, python-format
 msgid "'%(value)s' value must be a decimal number."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1500
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1500
 msgid "Decimal number"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1651
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1651
 #, python-format
 msgid ""
 "'%(value)s' value has an invalid format. It must be in [DD] [HH:[MM:]]ss[."
 "uuuuuu] format."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1654
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1654
 msgid "Duration"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1705
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1705
 msgid "Email address"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1729
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1729
 msgid "File path"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1796
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1796
 #, python-format
 msgid "'%(value)s' value must be a float."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1798
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1798
 msgid "Floating point number"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1899
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1899
 msgid "Big (8 byte) integer"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1914
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1914
 msgid "IPv4 address"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1950
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1950
 msgid "IP address"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2029
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2029
 #, python-format
 msgid "'%(value)s' value must be either None, True or False."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2031
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2031
 msgid "Boolean (Either True, False or None)"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2091
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2091
 msgid "Positive integer"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2103
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2103
 msgid "Positive small integer"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2116
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2116
 #, python-format
 msgid "Slug (up to %(max_length)s)"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2145
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2145
 msgid "Small integer"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2152
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2152
 #: wasa2il/templates/core/stub/document_view.html:84
 msgid "Text"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2175
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2175
 #, python-format
 msgid ""
 "'%(value)s' value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
 "format."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2177
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2177
 #, python-format
 msgid ""
 "'%(value)s' value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
 "invalid time."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2180
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2180
 msgid "Time"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2308
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2308
 msgid "URL"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2331
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2331
 msgid "Raw binary data"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2375
+#: venv/lib/python2.7/site-packages/django/db/models/fields/__init__.py:2375
 #, python-format
 msgid "'%(value)s' is not a valid UUID."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/files.py:238
+#: venv/lib/python2.7/site-packages/django/db/models/fields/files.py:238
 msgid "File"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/files.py:388
+#: venv/lib/python2.7/site-packages/django/db/models/fields/files.py:388
 msgid "Image"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/related.py:1809
+#: venv/lib/python2.7/site-packages/django/db/models/fields/related.py:1809
 #, python-format
 msgid "%(model)s instance with %(field)s %(value)r does not exist."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/related.py:1811
+#: venv/lib/python2.7/site-packages/django/db/models/fields/related.py:1811
 msgid "Foreign Key (type determined by related field)"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/related.py:2041
+#: venv/lib/python2.7/site-packages/django/db/models/fields/related.py:2041
 msgid "One-to-one relationship"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/db/models/fields/related.py:2131
+#: venv/lib/python2.7/site-packages/django/db/models/fields/related.py:2131
 msgid "Many-to-many relationship"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:64
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:64
 msgid "This field is required."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:237
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:237
 msgid "Enter a whole number."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:280
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:317
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:280
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:317
 msgid "Enter a number."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:319
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:319
 #, python-format
 msgid "Ensure that there are no more than %(max)s digit in total."
 msgid_plural "Ensure that there are no more than %(max)s digits in total."
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:323
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:323
 #, python-format
 msgid "Ensure that there are no more than %(max)s decimal place."
 msgid_plural "Ensure that there are no more than %(max)s decimal places."
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:327
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:327
 #, python-format
 msgid ""
 "Ensure that there are no more than %(max)s digit before the decimal point."
@@ -574,37 +574,37 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:438
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:1193
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:438
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:1193
 msgid "Enter a valid date."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:462
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:1194
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:462
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:1194
 msgid "Enter a valid time."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:484
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:484
 msgid "Enter a valid date/time."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:525
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:525
 msgid "Enter a valid duration."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:591
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:591
 msgid "No file was submitted. Check the encoding type on the form."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:592
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:592
 msgid "No file was submitted."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:593
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:593
 msgid "The submitted file is empty."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:595
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:595
 #, python-format
 msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
 msgid_plural ""
@@ -612,559 +612,559 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:598
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:598
 msgid "Please either submit a file or check the clear checkbox, not both."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:660
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:660
 msgid ""
 "Upload a valid image. The file you uploaded was either not an image or a "
 "corrupted image."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:827
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:921
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:1238
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:827
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:921
+#: venv/lib/python2.7/site-packages/django/forms/models.py:1238
 #, python-format
 msgid "Select a valid choice. %(value)s is not one of the available choices."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:922
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:1037
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:1237
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:922
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:1037
+#: venv/lib/python2.7/site-packages/django/forms/models.py:1237
 msgid "Enter a list of values."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:1038
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:1038
 msgid "Enter a complete value."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/fields.py:1264
+#: venv/lib/python2.7/site-packages/django/forms/fields.py:1264
 msgid "Enter a valid UUID."
 msgstr ""
 
 #. Translators: This is the default suffix added to form field labels
-#: local/env/lib/python2.7/site-packages/django/forms/forms.py:129
+#: venv/lib/python2.7/site-packages/django/forms/forms.py:129
 msgid ":"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/forms.py:214
+#: venv/lib/python2.7/site-packages/django/forms/forms.py:214
 #, python-format
 msgid "(Hidden field %(name)s) %(error)s"
 msgstr ""
 
 #. Translators: If found as last label character, these punctuation
 #. characters will prevent the default label_suffix to be appended to the label
-#: local/env/lib/python2.7/site-packages/django/forms/forms.py:659
+#: venv/lib/python2.7/site-packages/django/forms/forms.py:659
 msgid ":?.!"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/formsets.py:96
+#: venv/lib/python2.7/site-packages/django/forms/formsets.py:96
 msgid "ManagementForm data is missing or has been tampered with"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/formsets.py:333
+#: venv/lib/python2.7/site-packages/django/forms/formsets.py:333
 #, python-format
 msgid "Please submit %d or fewer forms."
 msgid_plural "Please submit %d or fewer forms."
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/formsets.py:340
+#: venv/lib/python2.7/site-packages/django/forms/formsets.py:340
 #, python-format
 msgid "Please submit %d or more forms."
 msgid_plural "Please submit %d or more forms."
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/formsets.py:368
-#: local/env/lib/python2.7/site-packages/django/forms/formsets.py:370
+#: venv/lib/python2.7/site-packages/django/forms/formsets.py:368
+#: venv/lib/python2.7/site-packages/django/forms/formsets.py:370
 msgid "Order"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/formsets.py:372
+#: venv/lib/python2.7/site-packages/django/forms/formsets.py:372
 msgid "Delete"
 msgstr "Eyða"
 
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:712
+#: venv/lib/python2.7/site-packages/django/forms/models.py:712
 #, python-format
 msgid "Please correct the duplicate data for %(field)s."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:716
+#: venv/lib/python2.7/site-packages/django/forms/models.py:716
 #, python-format
 msgid "Please correct the duplicate data for %(field)s, which must be unique."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:722
+#: venv/lib/python2.7/site-packages/django/forms/models.py:722
 #, python-format
 msgid ""
 "Please correct the duplicate data for %(field_name)s which must be unique "
 "for the %(lookup)s in %(date_field)s."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:730
+#: venv/lib/python2.7/site-packages/django/forms/models.py:730
 msgid "Please correct the duplicate values below."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:1053
+#: venv/lib/python2.7/site-packages/django/forms/models.py:1053
 msgid "The inline foreign key did not match the parent instance primary key."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:1123
+#: venv/lib/python2.7/site-packages/django/forms/models.py:1123
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/models.py:1240
+#: venv/lib/python2.7/site-packages/django/forms/models.py:1240
 #, python-format
 msgid "\"%(pk)s\" is not a valid value for a primary key."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/utils.py:165
+#: venv/lib/python2.7/site-packages/django/forms/utils.py:165
 #, python-format
 msgid ""
 "%(datetime)s couldn't be interpreted in time zone %(current_timezone)s; it "
 "may be ambiguous or it may not exist."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/widgets.py:345
+#: venv/lib/python2.7/site-packages/django/forms/widgets.py:345
 msgid "Currently"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/widgets.py:346
+#: venv/lib/python2.7/site-packages/django/forms/widgets.py:346
 msgid "Change"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/widgets.py:347
+#: venv/lib/python2.7/site-packages/django/forms/widgets.py:347
 msgid "Clear"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/widgets.py:555
+#: venv/lib/python2.7/site-packages/django/forms/widgets.py:555
 msgid "Unknown"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/forms/widgets.py:556
+#: venv/lib/python2.7/site-packages/django/forms/widgets.py:556
 #: wasa2il/templates/core/_document_agreement_list_table.html:5
 #: wasa2il/templates/core/issue_detail.html:44
 #: wasa2il/templates/core/issue_detail.html:80
 msgid "Yes"
 msgstr "Já"
 
-#: local/env/lib/python2.7/site-packages/django/forms/widgets.py:557
+#: venv/lib/python2.7/site-packages/django/forms/widgets.py:557
 #: wasa2il/templates/core/_document_agreement_list_table.html:6
 #: wasa2il/templates/core/issue_detail.html:45
 #: wasa2il/templates/core/issue_detail.html:82
 msgid "No"
 msgstr "Nei"
 
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:865
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:865
 msgid "yes,no,maybe"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:894
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:906
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:894
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:906
 #, python-format
 msgid "%(size)d byte"
 msgid_plural "%(size)d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:908
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:908
 #, python-format
 msgid "%s KB"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:910
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:910
 #, python-format
 msgid "%s MB"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:912
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:912
 #, python-format
 msgid "%s GB"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:914
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:914
 #, python-format
 msgid "%s TB"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/template/defaultfilters.py:916
+#: venv/lib/python2.7/site-packages/django/template/defaultfilters.py:916
 #, python-format
 msgid "%s PB"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dateformat.py:61
+#: venv/lib/python2.7/site-packages/django/utils/dateformat.py:61
 msgid "p.m."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dateformat.py:62
+#: venv/lib/python2.7/site-packages/django/utils/dateformat.py:62
 msgid "a.m."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dateformat.py:67
+#: venv/lib/python2.7/site-packages/django/utils/dateformat.py:67
 msgid "PM"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dateformat.py:68
+#: venv/lib/python2.7/site-packages/django/utils/dateformat.py:68
 msgid "AM"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dateformat.py:153
+#: venv/lib/python2.7/site-packages/django/utils/dateformat.py:153
 msgid "midnight"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dateformat.py:155
+#: venv/lib/python2.7/site-packages/django/utils/dateformat.py:155
 msgid "noon"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:6
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:6
 msgid "Monday"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:6
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:6
 msgid "Tuesday"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:6
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:6
 msgid "Wednesday"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:6
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:6
 msgid "Thursday"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:6
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:6
 msgid "Friday"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:7
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:7
 msgid "Saturday"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:7
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:7
 msgid "Sunday"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:10
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:10
 msgid "Mon"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:10
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:10
 msgid "Tue"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:10
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:10
 msgid "Wed"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:10
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:10
 msgid "Thu"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:10
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:10
 msgid "Fri"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:11
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:11
 msgid "Sat"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:11
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:11
 msgid "Sun"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:18
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:18
 msgid "January"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:18
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:18
 msgid "February"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:18
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:18
 msgid "March"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:18
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:18
 msgid "April"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:18
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:18
 msgid "May"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:18
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:18
 msgid "June"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:19
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:19
 msgid "July"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:19
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:19
 msgid "August"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:19
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:19
 msgid "September"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:19
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:19
 msgid "October"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:19
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:19
 msgid "November"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:20
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:20
 msgid "December"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:23
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:23
 msgid "jan"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:23
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:23
 msgid "feb"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:23
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:23
 msgid "mar"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:23
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:23
 msgid "apr"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:23
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:23
 msgid "may"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:23
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:23
 msgid "jun"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:24
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:24
 msgid "jul"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:24
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:24
 msgid "aug"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:24
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:24
 msgid "sep"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:24
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:24
 msgid "oct"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:24
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:24
 msgid "nov"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:24
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:24
 msgid "dec"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:31
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:31
 msgctxt "abbrev. month"
 msgid "Jan."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:32
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:32
 msgctxt "abbrev. month"
 msgid "Feb."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:33
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:33
 msgctxt "abbrev. month"
 msgid "March"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:34
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:34
 msgctxt "abbrev. month"
 msgid "April"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:35
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:35
 msgctxt "abbrev. month"
 msgid "May"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:36
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:36
 msgctxt "abbrev. month"
 msgid "June"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:37
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:37
 msgctxt "abbrev. month"
 msgid "July"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:38
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:38
 msgctxt "abbrev. month"
 msgid "Aug."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:39
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:39
 msgctxt "abbrev. month"
 msgid "Sept."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:40
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:40
 msgctxt "abbrev. month"
 msgid "Oct."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:41
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:41
 msgctxt "abbrev. month"
 msgid "Nov."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:42
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:42
 msgctxt "abbrev. month"
 msgid "Dec."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:45
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:45
 msgctxt "alt. month"
 msgid "January"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:46
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:46
 msgctxt "alt. month"
 msgid "February"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:47
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:47
 msgctxt "alt. month"
 msgid "March"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:48
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:48
 msgctxt "alt. month"
 msgid "April"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:49
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:49
 msgctxt "alt. month"
 msgid "May"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:50
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:50
 msgctxt "alt. month"
 msgid "June"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:51
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:51
 msgctxt "alt. month"
 msgid "July"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:52
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:52
 msgctxt "alt. month"
 msgid "August"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:53
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:53
 msgctxt "alt. month"
 msgid "September"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:54
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:54
 msgctxt "alt. month"
 msgid "October"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:55
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:55
 msgctxt "alt. month"
 msgid "November"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/dates.py:56
+#: venv/lib/python2.7/site-packages/django/utils/dates.py:56
 msgctxt "alt. month"
 msgid "December"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/ipv6.py:10
+#: venv/lib/python2.7/site-packages/django/utils/ipv6.py:10
 msgid "This is not a valid IPv6 address."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/text.py:79
+#: venv/lib/python2.7/site-packages/django/utils/text.py:79
 #, python-format
 msgctxt "String to return when truncating text"
 msgid "%(truncated_text)s..."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/text.py:248
+#: venv/lib/python2.7/site-packages/django/utils/text.py:248
 msgid "or"
 msgstr ""
 
 #. Translators: This string is used as a separator between list elements
-#: local/env/lib/python2.7/site-packages/django/utils/text.py:267
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:58
+#: venv/lib/python2.7/site-packages/django/utils/text.py:267
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:58
 msgid ", "
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:10
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:10
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:11
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:11
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:12
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:12
 #, python-format
 msgid "%d week"
 msgid_plural "%d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:13
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:13
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:14
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:14
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:15
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:15
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: local/env/lib/python2.7/site-packages/django/utils/timesince.py:47
+#: venv/lib/python2.7/site-packages/django/utils/timesince.py:47
 msgid "0 minutes"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/csrf.py:107
+#: venv/lib/python2.7/site-packages/django/views/csrf.py:107
 msgid "Forbidden"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/csrf.py:108
+#: venv/lib/python2.7/site-packages/django/views/csrf.py:108
 msgid "CSRF verification failed. Request aborted."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/csrf.py:112
+#: venv/lib/python2.7/site-packages/django/views/csrf.py:112
 msgid ""
 "You are seeing this message because this HTTPS site requires a 'Referer "
 "header' to be sent by your Web browser, but none was sent. This header is "
@@ -1172,117 +1172,117 @@ msgid ""
 "hijacked by third parties."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/csrf.py:117
+#: venv/lib/python2.7/site-packages/django/views/csrf.py:117
 msgid ""
 "If you have configured your browser to disable 'Referer' headers, please re-"
 "enable them, at least for this site, or for HTTPS connections, or for 'same-"
 "origin' requests."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/csrf.py:122
+#: venv/lib/python2.7/site-packages/django/views/csrf.py:122
 msgid ""
 "You are seeing this message because this site requires a CSRF cookie when "
 "submitting forms. This cookie is required for security reasons, to ensure "
 "that your browser is not being hijacked by third parties."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/csrf.py:127
+#: venv/lib/python2.7/site-packages/django/views/csrf.py:127
 msgid ""
 "If you have configured your browser to disable cookies, please re-enable "
 "them, at least for this site, or for 'same-origin' requests."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/csrf.py:132
+#: venv/lib/python2.7/site-packages/django/views/csrf.py:132
 msgid "More information is available with DEBUG=True."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/debug.py:583
+#: venv/lib/python2.7/site-packages/django/views/debug.py:583
 msgid "Welcome to Django"
 msgstr "Velkomin í Wasa2il!"
 
-#: local/env/lib/python2.7/site-packages/django/views/debug.py:584
+#: venv/lib/python2.7/site-packages/django/views/debug.py:584
 msgid "It worked!"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/debug.py:585
+#: venv/lib/python2.7/site-packages/django/views/debug.py:585
 msgid "Congratulations on your first Django-powered page."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/debug.py:586
+#: venv/lib/python2.7/site-packages/django/views/debug.py:586
 msgid ""
 "Of course, you haven't actually done any work yet. Next, start your first "
 "app by running <code>python manage.py startapp [app_label]</code>."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/debug.py:588
+#: venv/lib/python2.7/site-packages/django/views/debug.py:588
 msgid ""
 "You're seeing this message because you have <code>DEBUG = True</code> in "
 "your Django settings file and you haven't configured any URLs. Get to work!"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:48
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:48
 msgid "No year specified"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:104
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:104
 msgid "No month specified"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:163
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:163
 msgid "No day specified"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:219
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:219
 msgid "No week specified"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:378
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:406
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:378
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:406
 #, python-format
 msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:660
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:660
 #, python-format
 msgid ""
 "Future %(verbose_name_plural)s not available because %(class_name)s."
 "allow_future is False."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/dates.py:694
+#: venv/lib/python2.7/site-packages/django/views/generic/dates.py:694
 #, python-format
 msgid "Invalid date string '%(datestr)s' given format '%(format)s'"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/detail.py:55
+#: venv/lib/python2.7/site-packages/django/views/generic/detail.py:55
 #, python-format
 msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/list.py:76
+#: venv/lib/python2.7/site-packages/django/views/generic/list.py:76
 msgid "Page is not 'last', nor can it be converted to an int."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/list.py:81
+#: venv/lib/python2.7/site-packages/django/views/generic/list.py:81
 #, python-format
 msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/generic/list.py:172
+#: venv/lib/python2.7/site-packages/django/views/generic/list.py:172
 #, python-format
 msgid "Empty list and '%(class_name)s.allow_empty' is False."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/static.py:58
+#: venv/lib/python2.7/site-packages/django/views/static.py:58
 msgid "Directory indexes are not allowed here."
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/static.py:60
+#: venv/lib/python2.7/site-packages/django/views/static.py:60
 #, python-format
 msgid "\"%(path)s\" does not exist"
 msgstr ""
 
-#: local/env/lib/python2.7/site-packages/django/views/static.py:100
+#: venv/lib/python2.7/site-packages/django/views/static.py:100
 #, python-format
 msgid "Index of %(directory)s"
 msgstr ""
@@ -1323,7 +1323,29 @@ msgstr "Ef ekki, vinsamlegast sendið okkur póst á netfangið"
 msgid "Voting System - Pirate Party Iceland"
 msgstr "Kosningakerfi Pírata"
 
-#: wasa2il/templates/base.html:93 wasa2il/templates/help/is/agreement.html:6
+#: wasa2il/templates/base.html:91 wasa2il/templates/core/issue_detail.html:78
+msgid "There was an error while processing your vote. Please try again."
+msgstr ""
+"Það kom upp villa við úrvinnslu atkvæðisins þíns. Vinsamlegast reyndu aftur."
+
+#: wasa2il/templates/base.html:94
+msgid "Your votes have been submitted!"
+msgstr "Atkvæði þitt hefur verið móttekið!"
+
+#: wasa2il/templates/base.html:95
+msgid ""
+"You can continue adding, removing or reordering candidates until the "
+"deadline."
+msgstr ""
+"Þú getur haldið áfram að bæta við, fjarlægja eða umraða frambjóðendum þar "
+"til fresturinn rennur út."
+
+#: wasa2il/templates/base.html:98
+#: wasa2il/templates/core/election_detail.html:175
+msgid "Working..."
+msgstr "Sendi gögn..."
+
+#: wasa2il/templates/base.html:107 wasa2il/templates/help/is/agreement.html:6
 #: wasa2il/templates/help/is/authors.html:6
 #: wasa2il/templates/help/is/copyright.html:6
 #: wasa2il/templates/help/is/index.html:6
@@ -1333,49 +1355,49 @@ msgstr "Kosningakerfi Pírata"
 msgid "Help"
 msgstr "Hjálp"
 
-#: wasa2il/templates/base.html:99
+#: wasa2il/templates/base.html:113
 msgid "My profile"
 msgstr "Mín síða"
 
-#: wasa2il/templates/base.html:100
+#: wasa2il/templates/base.html:114
 msgid "My settings"
 msgstr "Stillingar"
 
-#: wasa2il/templates/base.html:102
+#: wasa2il/templates/base.html:116
 #: wasa2il/templates/registration/verification_needed.html:12
 msgid "Logout"
 msgstr "Útskrá"
 
-#: wasa2il/templates/base.html:106 wasa2il/templates/entry.html:17
+#: wasa2il/templates/base.html:120 wasa2il/templates/entry.html:17
 #: wasa2il/templates/registration/login.html:6
 #: wasa2il/templates/registration/password_reset_complete.html:9
 msgid "Log in"
 msgstr "Innskrá"
 
-#: wasa2il/templates/base.html:107 wasa2il/templates/entry.html:11
-#: wasa2il/templates/registration/login.html:19
+#: wasa2il/templates/base.html:121 wasa2il/templates/entry.html:11
+#: wasa2il/templates/registration/login.html:23
 #: wasa2il/templates/registration/registration_form.html:6
-#: wasa2il/templates/registration/registration_form.html:17
+#: wasa2il/templates/registration/registration_form.html:21
 msgid "Sign up"
 msgstr "Nýskrá"
 
-#: wasa2il/templates/base.html:113
+#: wasa2il/templates/base.html:127
 msgid "Search agreements"
 msgstr "Leita í samþykktum"
 
-#: wasa2il/templates/base.html:125
+#: wasa2il/templates/base.html:139
 msgid "Back to top"
 msgstr "Fara efst"
 
-#: wasa2il/templates/base.html:126
+#: wasa2il/templates/base.html:140
 msgid "About wasa2il"
 msgstr "Um wasa2il"
 
-#: wasa2il/templates/base.html:127
+#: wasa2il/templates/base.html:141
 msgid "License"
 msgstr "Notandaleyfi"
 
-#: wasa2il/templates/base.html:129 wasa2il/templates/help/is/authors.html:6
+#: wasa2il/templates/base.html:143 wasa2il/templates/help/is/authors.html:6
 msgid "Authors"
 msgstr "Höfundar"
 
@@ -1424,14 +1446,6 @@ msgstr "Sitja hjá"
 #: wasa2il/templates/core/_document_agreement_list_table.html:8
 msgid "Adopted"
 msgstr "Samþykkt"
-
-#: wasa2il/templates/core/_document_agreement_list_table.html:27
-msgid "No elections are scheduled at the moment."
-msgstr "Engar kosningar eru á dagskrá í augnablikinu."
-
-#: wasa2il/templates/core/_document_agreement_list_table.html:27
-msgid "There are no new issues at the moment."
-msgstr "Engin nýleg mál eru til umræðu í augnabliknu."
 
 #: wasa2il/templates/core/_document_agreement_list_table.html:27
 msgid "This polity has no agreements."
@@ -1483,7 +1497,7 @@ msgid "Statements:"
 msgstr "Statements:"
 
 #: wasa2il/templates/core/_document_modal.html:49
-#: wasa2il/templates/core/polity_detail.html:170
+#: wasa2il/templates/core/polity_detail.html:148
 #: wasa2il/templates/core/topic_detail.html:72
 #: wasa2il/templates/forum/forum_detail.html:48
 msgid "Close"
@@ -1514,24 +1528,38 @@ msgstr "Framlagðar tillögur"
 msgid "Adopted documents"
 msgstr "Samþykkt skjöl"
 
-#: wasa2il/templates/core/_election_candidate_list.html:23
+#: wasa2il/templates/core/_election_candidate_list.html:31
+#, fuzzy
+#| msgid "Back to top"
+msgid "Move to top"
+msgstr "Færa efst"
+
+#: wasa2il/templates/core/_election_candidate_list.html:35
+msgid "Move to bottom"
+msgstr "Færa neðst"
+
+#: wasa2il/templates/core/_election_candidate_list.html:39
+msgid "Remove"
+msgstr "Fjarlægja"
+
+#: wasa2il/templates/core/_election_candidate_list.html:49
 #: wasa2il/templates/core/issue_detail.html:77
 msgid "Vote"
 msgstr "Kjósa"
 
-#: wasa2il/templates/core/_election_candidate_list.html:33
+#: wasa2il/templates/core/_election_candidate_list.html:59
 msgid "Your ballot is empty."
 msgstr "Kjörseðillinn er tómur."
 
-#: wasa2il/templates/core/_election_candidate_list.html:34
+#: wasa2il/templates/core/_election_candidate_list.html:60
 msgid "Drag candidates here or click the vote buttons."
 msgstr "Dragðu frambjóðendur hingað eða smelltu á takka til að kjósa."
 
-#: wasa2il/templates/core/_election_candidate_list.html:36
+#: wasa2il/templates/core/_election_candidate_list.html:63
 msgid "You have selected all the candidates, good work!"
 msgstr "Þú hefur raðað öllum á seðilinn, vel gert!"
 
-#: wasa2il/templates/core/_election_candidate_list.html:36
+#: wasa2il/templates/core/_election_candidate_list.html:65
 msgid "There are no candidates standing in this election yet!"
 msgstr "Þessar kosningar hafa enga frambjóðendur enn sem komið er."
 
@@ -1546,7 +1574,7 @@ msgstr "Þú hefur ekki greitt atkvæði um þetta mál"
 #: wasa2il/templates/core/_election_list_table.html:11
 #: wasa2il/templates/core/election_list.html:25
 #: wasa2il/templates/core/issues_new.html:32
-#: wasa2il/templates/core/polity_detail.html:60
+#: wasa2il/templates/core/polity_detail.html:61
 #: wasa2il/templates/core/topic_detail.html:34
 msgid "Voting"
 msgstr "Í kosningu"
@@ -1554,7 +1582,7 @@ msgstr "Í kosningu"
 #: wasa2il/templates/core/_election_list_table.html:11
 #: wasa2il/templates/core/election_list.html:25
 #: wasa2il/templates/core/issues_new.html:32
-#: wasa2il/templates/core/polity_detail.html:60
+#: wasa2il/templates/core/polity_detail.html:61
 #: wasa2il/templates/core/topic_detail.html:34
 msgid "Open"
 msgstr "Opið"
@@ -1564,6 +1592,68 @@ msgstr "Opið"
 #: wasa2il/templates/core/topic_detail.html:34
 msgid "Closed"
 msgstr "Lokað"
+
+#: wasa2il/templates/core/_election_list_table.html:18
+msgid "No elections are scheduled at the moment."
+msgstr "Engar kosningar eru á dagskrá í augnablikinu."
+
+#: wasa2il/templates/core/_polity_detail_elections.html:8
+#: wasa2il/templates/core/election_form.html:28
+msgid "New election"
+msgstr "Ný kosning"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:13
+msgid "Show closed elections"
+msgstr "Sýna liðnar kosningar"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:14
+msgid "Show all elections"
+msgstr "Sýna allar kosningar"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:18
+#: wasa2il/templates/core/polity_detail.html:25
+msgid "Elections"
+msgstr "Kosningar"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:18
+msgid "putting people in power"
+msgstr "gefa fólki völd"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:20
+msgid ""
+"Sometimes you need to put people in their places. Elections do just that."
+msgstr "Stundum þarf að setja fólk á sinn stað. Kosningar gera einmitt það."
+
+#: wasa2il/templates/core/_polity_detail_elections.html:25
+#: wasa2il/templates/core/election_list.html:15
+msgid "Election"
+msgstr "Kosning"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:26
+#: wasa2il/templates/core/election_list.html:16
+#: wasa2il/templates/core/issues_new.html:19
+#: wasa2il/templates/core/polity_detail.html:48
+#: wasa2il/templates/core/topic_detail.html:22
+msgid "State"
+msgstr "Ástand"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:27
+#: wasa2il/templates/core/election_detail.html:91
+#: wasa2il/templates/core/election_detail.html:172
+#: wasa2il/templates/core/election_list.html:17
+msgid "Candidates"
+msgstr "Frambjóðendur"
+
+#: wasa2il/templates/core/_polity_detail_elections.html:28
+#: wasa2il/templates/core/election_detail.html:89
+#: wasa2il/templates/core/election_detail.html:148
+#: wasa2il/templates/core/election_list.html:18
+#: wasa2il/templates/core/issue_detail.html:42
+#: wasa2il/templates/core/issues_new.html:21
+#: wasa2il/templates/core/polity_detail.html:50
+#: wasa2il/templates/core/topic_detail.html:24
+msgid "Votes"
+msgstr "Atkvæði"
 
 #: wasa2il/templates/core/_topic_list_table.html:19
 msgid "There are no topics in this polity!"
@@ -1575,7 +1665,7 @@ msgstr "Stofna nýjan málaflokk"
 
 #: wasa2il/templates/core/delegate_detail.html:6
 #: wasa2il/templates/core/document_detail.html:14
-#: wasa2il/templates/core/election_detail.html:29
+#: wasa2il/templates/core/election_detail.html:31
 #: wasa2il/templates/core/election_list.html:8
 #: wasa2il/templates/core/issue_detail.html:6
 #: wasa2il/templates/core/issues_new.html:8
@@ -1658,13 +1748,13 @@ msgstr "Í þingi:"
 #: wasa2il/templates/forum/discussion_form.html:16
 #: wasa2il/templates/forum/forum_form.html:17
 #: wasa2il/templates/registration/password_change_form.html:21
-#: wasa2il/templates/registration/password_reset_confirm.html:14
+#: wasa2il/templates/registration/password_reset_confirm.html:13
 #: wasa2il/templates/settings.html:19
 msgid "Save"
 msgstr "Vista"
 
 #: wasa2il/templates/core/document_list.html:7
-#: wasa2il/templates/core/polity_detail.html:72
+#: wasa2il/templates/core/polity_detail.html:83
 msgid "New document"
 msgstr "Nýtt skjal"
 
@@ -1689,7 +1779,7 @@ msgstr "Tillaga"
 #: wasa2il/templates/core/document_update.html:115
 #: wasa2il/templates/core/document_update.html:192
 #: wasa2il/templates/core/issues_new.html:20
-#: wasa2il/templates/core/polity_detail.html:48
+#: wasa2il/templates/core/polity_detail.html:49
 #: wasa2il/templates/core/topic_detail.html:23
 msgid "Comments"
 msgstr "Ummæli"
@@ -1746,196 +1836,138 @@ msgstr "Höfundur"
 msgid "New draft"
 msgstr "Ný drög"
 
-#: wasa2il/templates/core/election_detail.html:31
+#: wasa2il/templates/core/election_detail.html:33
 msgid "Election:"
 msgstr "Kosning:"
 
-#: wasa2il/templates/core/election_detail.html:34
+#: wasa2il/templates/core/election_detail.html:36
 msgid "This election is closed."
 msgstr "Þessu máli er lokið."
 
-#: wasa2il/templates/core/election_detail.html:37
+#: wasa2il/templates/core/election_detail.html:39
 msgid "You cannot vote in this election:"
 msgstr "Þú getur ekki kosið í þessum kosningum:"
 
-#: wasa2il/templates/core/election_detail.html:39
-#: wasa2il/templates/core/election_detail.html:52
+#: wasa2il/templates/core/election_detail.html:41
+#: wasa2il/templates/core/election_detail.html:54
 msgid "Please log in."
 msgstr "Vinsamlegast skráðu þig inn."
 
-#: wasa2il/templates/core/election_detail.html:41
+#: wasa2il/templates/core/election_detail.html:43
 msgid "You joined the organization too late."
 msgstr ""
 
-#: wasa2il/templates/core/election_detail.html:43
-#: wasa2il/templates/core/election_detail.html:54
+#: wasa2il/templates/core/election_detail.html:45
+#: wasa2il/templates/core/election_detail.html:56
 msgid "You are not a member of this polity."
 msgstr "Þú ert ekki meðlimur þessa þings."
 
-#: wasa2il/templates/core/election_detail.html:45
-#: wasa2il/templates/core/election_detail.html:56
+#: wasa2il/templates/core/election_detail.html:47
+#: wasa2il/templates/core/election_detail.html:58
 msgid "You do not meet the requirements."
 msgstr "Þú uppfyllir ekki skilyrðin."
 
-#: wasa2il/templates/core/election_detail.html:50
+#: wasa2il/templates/core/election_detail.html:52
 msgid "You cannot run in this election:"
 msgstr "Þú getur ekki farið fram í þessum kosningum:"
 
-#: wasa2il/templates/core/election_detail.html:63
+#: wasa2il/templates/core/election_detail.html:65
 msgid "This election is delegated."
 msgstr ""
 
-#: wasa2il/templates/core/election_detail.html:63
+#: wasa2il/templates/core/election_detail.html:65
 #: wasa2il/templates/core/topic_detail.html:12
 msgid "View details."
 msgstr "Birta smáatriði."
 
-#: wasa2il/templates/core/election_detail.html:71
+#: wasa2il/templates/core/election_detail.html:73
 msgid "Voting begins"
 msgstr "Kosningar hefjast"
 
-#: wasa2il/templates/core/election_detail.html:75
+#: wasa2il/templates/core/election_detail.html:80
 msgid "Candidacy polities"
 msgstr "Þing frambjóðenda"
 
-#: wasa2il/templates/core/election_detail.html:78
+#: wasa2il/templates/core/election_detail.html:81
 msgid "You can run"
 msgstr "Mátt bjóða fram"
 
-#: wasa2il/templates/core/election_detail.html:82
+#: wasa2il/templates/core/election_detail.html:85
 msgid "Voting polities"
 msgstr "Þing kjósenda"
 
-#: wasa2il/templates/core/election_detail.html:83
+#: wasa2il/templates/core/election_detail.html:86
 msgid "You can vote"
 msgstr "Mátt kjósa"
 
-#: wasa2il/templates/core/election_detail.html:86
-#: wasa2il/templates/core/election_detail.html:145
-#: wasa2il/templates/core/election_list.html:18
-#: wasa2il/templates/core/issue_detail.html:42
-#: wasa2il/templates/core/issues_new.html:21
-#: wasa2il/templates/core/polity_detail.html:49
-#: wasa2il/templates/core/polity_detail.html:142
-#: wasa2il/templates/core/topic_detail.html:24
-msgid "Votes"
-msgstr "Atkvæði"
-
-#: wasa2il/templates/core/election_detail.html:81
-#: wasa2il/templates/core/election_detail.html:170
-#: wasa2il/templates/core/election_list.html:17
-#: wasa2il/templates/core/polity_detail.html:141
-msgid "Candidates"
-msgstr "Frambjóðendur"
-
-#: wasa2il/templates/core/election_detail.html:84
+#: wasa2il/templates/core/election_detail.html:95
 msgid "Details ..."
 msgstr "Upplýsingar ..."
 
-#: wasa2il/templates/core/election_detail.html:93
-#: wasa2il/templates/core/election_detail.html:152
+#: wasa2il/templates/core/election_detail.html:105
+#: wasa2il/templates/core/election_detail.html:154
 msgid "About This Election"
 msgstr "Um Þessar Kosningar"
 
-#: wasa2il/templates/core/election_detail.html:102
+#: wasa2il/templates/core/election_detail.html:114
 msgid "Election results"
 msgstr "Niðurstöður kosningar"
 
-#: wasa2il/templates/core/election_detail.html:118
+#: wasa2il/templates/core/election_detail.html:130
 msgid "No votes were cast."
 msgstr "Engin atkvæði voru greidd."
 
-#: wasa2il/templates/core/election_detail.html:122
+#: wasa2il/templates/core/election_detail.html:134
 msgid "Votes are still being counted."
 msgstr "Enn er verið að telja atkvæðin."
 
-#: wasa2il/templates/core/election_detail.html:136
+#: wasa2il/templates/core/election_detail.html:148
 msgid "your favorites first!"
 msgstr "uppáhaldin þín efst!"
 
-#: wasa2il/templates/core/election_detail.html:141
-#: wasa2il/templates/core/issue_detail.html:78
-msgid "There was an error while processing your vote. Please try again."
-msgstr ""
-"Það kom upp villa við úrvinnslu atkvæðisins þíns. Vinsamlegast reyndu aftur."
-
-#: wasa2il/templates/core/election_detail.html:144
-msgid "Your votes have been submitted!"
-msgstr "Atkvæði þitt hefur verið móttekið!"
-
-#: wasa2il/templates/core/election_detail.html:145
-msgid ""
-"You can continue adding, removing or reordering candidates until the "
-"deadline."
-msgstr ""
-"Þú getur haldið áfram að bæta við, fjarlægja eða umraða frambjóðendum þar "
-"til fresturinn rennur út."
-
-#: wasa2il/templates/core/election_detail.html:148
-msgid "Working..."
-msgstr "Sendi gögn..."
-
-#: wasa2il/templates/core/election_detail.html:155
+#: wasa2il/templates/core/election_detail.html:157
 msgid "How To Vote"
 msgstr "Hvernig Skal Kjósa"
 
-#: wasa2il/templates/core/election_detail.html:157
+#: wasa2il/templates/core/election_detail.html:159
 msgid "Click the Start Voting button to begin"
 msgstr "Smelltu á Opna Kjörseðil hnappinn til að byrja"
 
-#: wasa2il/templates/core/election_detail.html:158
+#: wasa2il/templates/core/election_detail.html:160
 msgid "Click a Vote button to vote for a candidate"
 msgstr "Smelltu á Kjósa hnapp til að kjósa frambjóðanda"
 
-#: wasa2il/templates/core/election_detail.html:159
+#: wasa2il/templates/core/election_detail.html:161
 msgid "Click the arrows to move your favorite candidates to the top"
 msgstr "Smelltu á örvarnar til að raða bestu frambjóðendunum í efstu sætin"
 
-#: wasa2il/templates/core/election_detail.html:160
+#: wasa2il/templates/core/election_detail.html:162
 msgid "Your vote will be counted when the deadline has passed"
 msgstr "Atkvæði þitt verður talið þegar fresturinn rennur út"
 
-#: wasa2il/templates/core/election_detail.html:163
+#: wasa2il/templates/core/election_detail.html:165
 msgid "Start Voting"
 msgstr "Opna Kjörseðil"
 
-#: wasa2il/templates/core/election_detail.html:170
+#: wasa2il/templates/core/election_detail.html:172
 msgid "running in this election"
 msgstr "í þessari kosningu"
 
-#: wasa2il/templates/core/election_detail.html:172
+#: wasa2il/templates/core/election_detail.html:177
 msgid "Announce candidacy"
 msgstr "Tilkynna framboð"
 
-#: wasa2il/templates/core/election_detail.html:179
+#: wasa2il/templates/core/election_detail.html:180
 msgid "Are you sure you want to withdraw? This can not be undone."
 msgstr "Ertu viss um að draga framboð þitt til baka? Það er óafturkræft."
 
-#: wasa2il/templates/core/election_detail.html:181
+#: wasa2il/templates/core/election_detail.html:182
 msgid "Withdraw candidacy"
 msgstr "Draga framboð til baka"
-
-#: wasa2il/templates/core/election_form.html:28
-#: wasa2il/templates/core/polity_detail.html:122
-msgid "New election"
-msgstr "Ný kosning"
 
 #: wasa2il/templates/core/election_list.html:10
 msgid "Elections in polity"
 msgstr "Kosningar í þingi"
-
-#: wasa2il/templates/core/election_list.html:15
-#: wasa2il/templates/core/polity_detail.html:139
-msgid "Election"
-msgstr "Kosning"
-
-#: wasa2il/templates/core/election_list.html:16
-#: wasa2il/templates/core/issues_new.html:19
-#: wasa2il/templates/core/polity_detail.html:47
-#: wasa2il/templates/core/polity_detail.html:140
-#: wasa2il/templates/core/topic_detail.html:22
-msgid "State"
-msgstr "Ástand"
 
 #: wasa2il/templates/core/issue_detail.html:24
 msgid "In topics"
@@ -1981,34 +2013,34 @@ msgstr "Nýtt mál"
 
 #: wasa2il/templates/core/issues_new.html:10
 #: wasa2il/templates/core/polity_detail.html:22
-#: wasa2il/templates/core/polity_detail.html:39
+#: wasa2il/templates/core/polity_detail.html:40
 msgid "New issues"
 msgstr "Ný mál"
 
 #: wasa2il/templates/core/issues_new.html:10
-#: wasa2il/templates/core/polity_detail.html:39
+#: wasa2il/templates/core/polity_detail.html:40
 msgid "in discussion"
 msgstr "til umræðu"
 
 #: wasa2il/templates/core/issues_new.html:11
-#: wasa2il/templates/core/polity_detail.html:41
+#: wasa2il/templates/core/polity_detail.html:42
 msgid "These are the newest issues being discussed in this polity."
 msgstr "Þetta eru nýjustu málin til umræðu í þessu þingi."
 
 #: wasa2il/templates/core/issues_new.html:29
-#: wasa2il/templates/core/polity_detail.html:57
+#: wasa2il/templates/core/polity_detail.html:58
 #: wasa2il/templates/core/topic_detail.html:30
 msgid "You have voted on this issue"
 msgstr "Þú hefur greitt atkvæði í þessu máli"
 
 #: wasa2il/templates/core/issues_new.html:29
-#: wasa2il/templates/core/polity_detail.html:57
+#: wasa2il/templates/core/polity_detail.html:58
 #: wasa2il/templates/core/topic_detail.html:30
 msgid "You have not voted on this issue"
 msgstr "Þú hefur ekki greitt atkvæði í þessu máli"
 
 #: wasa2il/templates/core/issues_new.html:32
-#: wasa2il/templates/core/polity_detail.html:60
+#: wasa2il/templates/core/polity_detail.html:61
 msgid "New"
 msgstr ""
 
@@ -2021,76 +2053,58 @@ msgid "You are a member of this polity."
 msgstr "Þú ert meðlimur þessa þings."
 
 #: wasa2il/templates/core/polity_detail.html:23
-#: wasa2il/templates/core/polity_detail.html:75
+#: wasa2il/templates/core/polity_detail.html:86
 #: wasa2il/templates/help/is/agreement.html:6
 msgid "Agreements"
 msgstr "Samþykktir"
 
-#: wasa2il/templates/core/polity_detail.html:25
-#: wasa2il/templates/core/polity_detail.html:132
-msgid "Elections"
-msgstr "Kosningar"
-
-#: wasa2il/templates/core/polity_detail.html:35
+#: wasa2il/templates/core/polity_detail.html:36
 msgid "Show all new issues"
 msgstr "Sýna öll ný mál"
 
-#: wasa2il/templates/core/polity_detail.html:75
+#: wasa2il/templates/core/polity_detail.html:68
+msgid "There are no new issues at the moment."
+msgstr "Engin nýleg mál eru til umræðu í augnabliknu."
+
+#: wasa2il/templates/core/polity_detail.html:86
 msgid "of this polity"
 msgstr "þessa þings"
 
-#: wasa2il/templates/core/polity_detail.html:77
+#: wasa2il/templates/core/polity_detail.html:88
 msgid "Here are all of the agreements this polity has arrived at."
 msgstr "Hér eru allar samþykktir þessa þings."
 
-#: wasa2il/templates/core/polity_detail.html:88
+#: wasa2il/templates/core/polity_detail.html:99
 #: wasa2il/templates/core/topic_form.html:6
 msgid "New topic"
 msgstr "Nýr málaflokkur"
 
-#: wasa2il/templates/core/polity_detail.html:92
+#: wasa2il/templates/core/polity_detail.html:103
 msgid "Show only starred topics"
 msgstr "Sýna bara stjörnumerkta málaflokka"
 
-#: wasa2il/templates/core/polity_detail.html:96
+#: wasa2il/templates/core/polity_detail.html:107
 msgid "of discussion"
 msgstr "til umræðu"
 
-#: wasa2il/templates/core/polity_detail.html:98
+#: wasa2il/templates/core/polity_detail.html:109
 msgid "Topics are thematic categories that contain specific issues."
 msgstr "Málaflokkar eru flokkar með þemu sem innihalda mál."
 
-#: wasa2il/templates/core/polity_detail.html:104
+#: wasa2il/templates/core/polity_detail.html:115
 #: wasa2il/templates/core/topic_detail.html:21
 msgid "Issues"
 msgstr "Mál"
 
-#: wasa2il/templates/core/polity_detail.html:105
+#: wasa2il/templates/core/polity_detail.html:116
 msgid "Open Issues"
 msgstr "Opin mál"
 
-#: wasa2il/templates/core/polity_detail.html:106
+#: wasa2il/templates/core/polity_detail.html:117
 msgid "Voting Issues"
 msgstr "Mál í kosningu"
 
-#: wasa2il/templates/core/polity_detail.html:127
-msgid "Show closed elections"
-msgstr "Sýna liðnar kosningar"
-
-#: wasa2il/templates/core/polity_detail.html:128
-msgid "Show all elections"
-msgstr "Sýna allar kosningar"
-
-#: wasa2il/templates/core/polity_detail.html:132
-msgid "putting people in power"
-msgstr "gefa fólki völd"
-
-#: wasa2il/templates/core/polity_detail.html:134
-msgid ""
-"Sometimes you need to put people in their places. Elections do just that."
-msgstr "Stundum þarf að setja fólk á sinn stað. Kosningar gera einmitt það."
-
-#: wasa2il/templates/core/polity_detail.html:160
+#: wasa2il/templates/core/polity_detail.html:138
 msgid "Subpolities"
 msgstr "Undirþing"
 
@@ -2772,7 +2786,7 @@ msgid "You may now try to log in!"
 msgstr "Þú getur núna reynt að innskrá þig!"
 
 #: wasa2il/templates/registration/activation_complete.html:13
-#: wasa2il/templates/registration/login.html:18
+#: wasa2il/templates/registration/login.html:22
 msgid "Login"
 msgstr "Innskrá"
 
@@ -2808,20 +2822,20 @@ msgstr ""
 "Vinsamlegast athugið að með því að nýskrá og staðfesta aðgang gerist þú "
 "meðlimur að Pírötum."
 
-#: wasa2il/templates/registration/data_disclaimer.html:4
+#: wasa2il/templates/registration/data_disclaimer.html:5
 msgid ""
 "Membership of political organizations is considered sensitive information by "
 "law."
 msgstr ""
 "Félagatöl stjórnmálaafla teljast til persónulegra gagna samkvæmt lögum."
 
-#: wasa2il/templates/registration/data_disclaimer.html:5
+#: wasa2il/templates/registration/data_disclaimer.html:6
 msgid ""
 "Therefore, you should keep the following in mind when becoming a member and "
 "using our system:"
 msgstr "Því ættirðu að hafa eftirfarandi í huga þegar þú notar kerfin okkar:"
 
-#: wasa2il/templates/registration/data_disclaimer.html:7
+#: wasa2il/templates/registration/data_disclaimer.html:8
 msgid ""
 "Your username is publicly visible. If you don't want to be recognized, use a "
 "different one than what you use elsewhere."
@@ -2829,7 +2843,7 @@ msgstr ""
 "Notandanafnið þitt er sýnilegt öllum. Ef þú vilt fela auðkenni þitt, notaðu "
 "annað en þau sem þú notar annars staðar."
 
-#: wasa2il/templates/registration/data_disclaimer.html:8
+#: wasa2il/templates/registration/data_disclaimer.html:9
 msgid ""
 "Your profile settings <strong>are mostly public</strong>, including your "
 "display name, image and description. We don't fill that out for you, though."
@@ -2837,15 +2851,15 @@ msgstr ""
 "Prófíllinn þinn <strong>er að mestu sýnilegur opinberlega</strong>, þar á "
 "meðal nafn þitt, mynd og lýsing. Við fyllum prófílinn þó ekki út fyrir þig."
 
-#: wasa2il/templates/registration/data_disclaimer.html:9
+#: wasa2il/templates/registration/data_disclaimer.html:10
 msgid "Don't put anything in there that you don't want visible to the public."
 msgstr "Ekki setja neitt í prófílinn þinn sem þú vilt ekki að sjáist út á við."
 
-#: wasa2il/templates/registration/data_disclaimer.html:10
+#: wasa2il/templates/registration/data_disclaimer.html:11
 msgid "We do <strong>not</strong> display your email address in public."
 msgstr "Við sýnum <strong>ekki</strong> netföng notenda okkar opinberlega."
 
-#: wasa2il/templates/registration/data_disclaimer.html:11
+#: wasa2il/templates/registration/data_disclaimer.html:12
 msgid "If you have questions or concerns regarding privacy, please email us:"
 msgstr ""
 "Ef einhverjar spurningar vakna varðandi persónugögn, vinsamlegast sendið "
@@ -2856,22 +2870,22 @@ msgstr ""
 msgid "and partake in democracy..."
 msgstr "og taktu þátt í lýðræðinu..."
 
-#: wasa2il/templates/registration/login.html:8
+#: wasa2il/templates/registration/login.html:9
 msgid ""
 "If you forgot your username, you can log in or reset your password with your "
 "email address or SSN instead."
 msgstr ""
-"Ef þú hefur gleymt notendanafni þínu, þá má einnig nota netfang eða kennitölu "
-"til að skrá sig inn eða panta nýtt lykilorð."
+"Ef þú hefur gleymt notendanafni þínu, þá má einnig nota netfang eða "
+"kennitölu til að skrá sig inn eða panta nýtt lykilorð."
 
-#: wasa2il/templates/registration/login.html:9
+#: wasa2il/templates/registration/login.html:11
 msgid "If problems arise, please send an email to the following email address:"
 msgstr ""
 "Ef vandamál koma upp, vinsamlegast sendið netpóst á eftirfarandi netfang:"
 
-#: wasa2il/templates/registration/login.html:20
+#: wasa2il/templates/registration/login.html:24
 #: wasa2il/templates/registration/password_reset_complete.html:5
-#: wasa2il/templates/registration/password_reset_confirm.html:6
+#: wasa2il/templates/registration/password_reset_confirm.html:8
 #: wasa2il/templates/registration/password_reset_done.html:5
 #: wasa2il/templates/registration/password_reset_form.html:5
 msgid "Password reset"
@@ -2903,11 +2917,11 @@ msgstr "Aftur í stillingar"
 msgid "Password reset successfully"
 msgstr "Lykilorðinu hefur verið breytt"
 
-#: wasa2il/templates/registration/password_reset_confirm.html:19
+#: wasa2il/templates/registration/password_reset_confirm.html:22
 msgid "Error"
 msgstr "Villa"
 
-#: wasa2il/templates/registration/password_reset_confirm.html:19
+#: wasa2il/templates/registration/password_reset_confirm.html:23
 msgid "Password reset failed"
 msgstr "Mistókst að breyta lykilorðinu! Kannski var vefslóðin úrelt?"
 
@@ -2943,8 +2957,8 @@ msgid ""
 "For security and privacy reasons, we cannot tell you whether you used the "
 "correct email address. Sorry!"
 msgstr ""
-"Af öryggis- og persónuverndarástæðum, getum við því miður ekki gefið það "
-"upp á vefnum hvort þú notaðir rétt netfang."
+"Af öryggis- og persónuverndarástæðum, getum við því miður ekki gefið það upp "
+"á vefnum hvort þú notaðir rétt netfang."
 
 #: wasa2il/templates/registration/password_reset_done.html:14
 msgid "Still nothing? Try creating a new account."

--- a/wasa2il/templates/core/_election_candidate_list.html
+++ b/wasa2il/templates/core/_election_candidate_list.html
@@ -28,20 +28,20 @@
                     <div class="dropdown-menu dropdown-menu-right">
                       <div class="vote-tip" onclick="election_top_candidate(this);">
                         <span class="glyphicon glyphicon-step-forward" style="transform: rotate(-90deg);" aria-hidden="true"></span>
-                        Vote to top
+                        {% trans "Move to top" %}
                       </div>
                       <div class="vote-tip" onclick="election_bottom_candidate(this);">
                         <span class="glyphicon glyphicon-step-forward" style="transform: rotate(90deg);"  aria-hidden="true"></span>
-                        Vote to bottom
+                        {% trans "Move to bottom" %}
                       </div>
                       <div class="vote-tip" onclick="election_deselect_candidate(this);">
                         <span class="glyphicon glyphicon-remove" style="color: #C00" aria-hidden="true"></span>
-                        Remove
+                        {% trans "Remove" %}
                       </div>
                     </div> <!-- End dropdown-menu -->
                   </div> <!-- End dropdown -->
                 </div>
-                 
+
                 {% endif %}
             {% else %}
                 {% if user_can_vote %}

--- a/wasa2il/templates/core/_election_candidate_list.html
+++ b/wasa2il/templates/core/_election_candidate_list.html
@@ -15,33 +15,31 @@
             {% if candidate_selected %}
                 {% if user_can_vote %}
                 <div class="col-xs-6">
-                  <div class="row">
-
-                    <div class="col-xs-12" >
-                      <button class="btn btn-default vote-button vote-up"     style="color:#000" onclick="election_up_candidate(this);">
-                        <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
-                      </button>
-                      <button class="btn btn-default vote-button vote-top"    style="color:#000" onclick="election_top_candidate(this);">
-                        <span class="glyphicon glyphicon-forward" style="transform: rotate(-90deg);" aria-hidden="true"></span>
-                      </button>
-                      <button class="btn btn-default vote-button vote-remove" style="color:#C00" onclick="election_deselect_candidate(this);">
-                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                      </button>
-                    </div>
-
-                    <div class="col-xs-12">
-                      <button class="btn btn-default vote-button vote-down"   style="color:#000" onclick="election_down_candidate(this);">
-                        <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
-                      </button>
-                      <button class="btn btn-default vote-button vote-bottom" style="color:#000" onclick="election_bottom_candidate(this);">
-                        <span class="glyphicon glyphicon-forward" style="transform: rotate(90deg);"  aria-hidden="true"></span>
-                      </button>
-                      <button class="btn btn-default vote-freeze"     style="color:#000" onclick="election_freeze_candidate(this);">
-                        <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-                      </button>
-                    </div>
-
-                  </div> <!-- end row -->
+                  <button class="btn btn-default vote-button vote-up"     style="color:#000" onclick="election_up_candidate(this);">
+                    <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
+                  </button>
+                  <button class="btn btn-default vote-button vote-down"   style="color:#000" onclick="election_down_candidate(this);">
+                    <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
+                  </button>
+                  <div class="dropdown" style="display: inline";>
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                      <span class="glyphicon glyphicon-option-horizontal" span>
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-right">
+                      <div class="vote-tip" onclick="election_top_candidate(this);">
+                        <span class="glyphicon glyphicon-step-forward" style="transform: rotate(-90deg);" aria-hidden="true"></span>
+                        Vote to top
+                      </div>
+                      <div class="vote-tip" onclick="election_bottom_candidate(this);">
+                        <span class="glyphicon glyphicon-step-forward" style="transform: rotate(90deg);"  aria-hidden="true"></span>
+                        Vote to bottom
+                      </div>
+                      <div class="vote-tip" onclick="election_deselect_candidate(this);">
+                        <span class="glyphicon glyphicon-remove" style="color: #C00" aria-hidden="true"></span>
+                        Remove
+                      </div>
+                    </div> <!-- End dropdown-menu -->
+                  </div> <!-- End dropdown -->
                 </div>
                  
                 {% endif %}

--- a/wasa2il/templates/core/_election_candidate_list.html
+++ b/wasa2il/templates/core/_election_candidate_list.html
@@ -22,7 +22,7 @@
                         <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
                       </button>
                       <button class="btn btn-default vote-button vote-top"    style="color:#000" onclick="election_top_candidate(this);">
-                        <span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span>
+                        <span class="glyphicon glyphicon-forward" style="transform: rotate(-90deg);" aria-hidden="true"></span>
                       </button>
                       <button class="btn btn-default vote-button vote-remove" style="color:#C00" onclick="election_deselect_candidate(this);">
                         <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
@@ -34,10 +34,10 @@
                         <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
                       </button>
                       <button class="btn btn-default vote-button vote-bottom" style="color:#000" onclick="election_bottom_candidate(this);">
-                        <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+                        <span class="glyphicon glyphicon-forward" style="transform: rotate(90deg);"  aria-hidden="true"></span>
                       </button>
-                      <button class="btn btn-default vote-button vote-freeze"     style="color:#000" onclick="election_freeze_candidate(this);">
-                        <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+                      <button class="btn btn-default vote-freeze"     style="color:#000" onclick="election_freeze_candidate(this);">
+                        <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
                       </button>
                     </div>
 
@@ -47,7 +47,7 @@
                 {% endif %}
             {% else %}
                 {% if user_can_vote %}
-                <div class="col-xs-6" style="outline: 1px dottet red">
+                <div class="col-xs-6">
                     <button class="btn btn-default vote-button vote-yes" onclick="election_select_candidate(this);">{% trans "Vote" %}</button>
                 </div>
                 {% endif %}

--- a/wasa2il/templates/core/_election_candidate_list.html
+++ b/wasa2il/templates/core/_election_candidate_list.html
@@ -21,6 +21,9 @@
                   <button class="btn btn-default vote-button vote-down"   style="color:#000" onclick="election_down_candidate(this);">
                     <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
                   </button>
+                  <button class="btn btn-default vote-button vote-down"   style="color:#C00" onclick="election_deselect_candidate(this);">
+                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                  </button>
                   <div class="dropdown" style="display: inline";>
                     <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
                       <span class="glyphicon glyphicon-option-horizontal" span>
@@ -34,13 +37,9 @@
                         <span class="glyphicon glyphicon-step-forward" style="transform: rotate(90deg);"  aria-hidden="true"></span>
                         {% trans "Move to bottom" %}
                       </div>
-                      <div class="vote-tip" onclick="election_deselect_candidate(this);">
-                        <span class="glyphicon glyphicon-remove" style="color: #C00" aria-hidden="true"></span>
-                        {% trans "Remove" %}
-                      </div>
-                    </div> <!-- End dropdown-menu -->
+                   </div> <!-- End dropdown-menu -->
                   </div> <!-- End dropdown -->
-                </div>
+                </div> <!-- End col -->
 
                 {% endif %}
             {% else %}

--- a/wasa2il/templates/core/_election_candidate_list.html
+++ b/wasa2il/templates/core/_election_candidate_list.html
@@ -4,29 +4,56 @@
 {% if not election.is_closed %}
 {% for candidate in candidates %}
 <li data-seqid="{{candidate.id}}">
-    <div style="position: relative;">
+    <div class="row">
+        <div class="col-xs-2">
+          <img src="{{ candidate.user.userprofile.picture|thumbnail:'50x50' }}" class="img-rounded vote-image" />
+        </div>
+        <div class="col-xs-4">
+          <a href="/accounts/profile/{{ candidate.user.username }}/" style="font-size: 15px;">{{ candidate.user.get_name | truncatechars:80 }}</a>
+        </div>
         {% if election.is_voting %}
             {% if candidate_selected %}
                 {% if user_can_vote %}
-                    <button class="btn btn-default vote-button vote-remove" style="color:#C00" onclick="election_deselect_candidate(this);">
-                      <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                    </button>
-                    <button class="btn btn-default vote-button vote-down"   style="color:#000" onclick="election_down_candidate(this);">
-                      <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
-                    </button>
-                    <button class="btn btn-default vote-button vote-up"     style="color:#000" onclick="election_up_candidate(this);">
-                      <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
-                    </button>
+                <div class="col-xs-6">
+                  <div class="row">
+
+                    <div class="col-xs-12" >
+                      <button class="btn btn-default vote-button vote-up"     style="color:#000" onclick="election_up_candidate(this);">
+                        <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
+                      </button>
+                      <button class="btn btn-default vote-button vote-top"    style="color:#000" onclick="election_top_candidate(this);">
+                        <span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span>
+                      </button>
+                      <button class="btn btn-default vote-button vote-remove" style="color:#C00" onclick="election_deselect_candidate(this);">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                      </button>
+                    </div>
+
+                    <div class="col-xs-12">
+                      <button class="btn btn-default vote-button vote-down"   style="color:#000" onclick="election_down_candidate(this);">
+                        <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
+                      </button>
+                      <button class="btn btn-default vote-button vote-bottom" style="color:#000" onclick="election_bottom_candidate(this);">
+                        <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+                      </button>
+                      <button class="btn btn-default vote-button vote-freeze"     style="color:#000" onclick="election_freeze_candidate(this);">
+                        <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+                      </button>
+                    </div>
+
+                  </div> <!-- end row -->
+                </div>
+                 
                 {% endif %}
             {% else %}
                 {% if user_can_vote %}
+                <div class="col-xs-6" style="outline: 1px dottet red">
                     <button class="btn btn-default vote-button vote-yes" onclick="election_select_candidate(this);">{% trans "Vote" %}</button>
+                </div>
                 {% endif %}
             {% endif %}
         {% endif %}
-        <img src="{{ candidate.user.userprofile.picture|thumbnail:'50x50' }}" class="img-rounded vote-image" />
-        <a href="/accounts/profile/{{ candidate.user.username }}/" style="font-size: 15px;">{{ candidate.user.get_name | truncatechars:80 }}</a>
-    </div>
+    </div> <!-- end row -->
 </li>
 {% empty %}
 {% if candidate_selected %}

--- a/wasa2il/templates/core/election_detail.html
+++ b/wasa2il/templates/core/election_detail.html
@@ -238,8 +238,15 @@ function election_bottom_candidate(element) {
 }
 
 function election_freeze_candidate(element) {
-    console.log('freeze');
-    election_update();
+    //$(element).closest('li').toggleClass("frozen"); // opacity
+    $(element).find('span').toggleClass("glyphicon-check").toggleClass("glyphicon-edit");
+    votebuttons = $(element).closest('li').find('.vote-button');
+    if(votebuttons.prop('disabled')){
+      votebuttons.prop('disabled', false);
+    } else {
+      votebuttons.prop('disabled', true);
+    }
+
 }
 
 function election_update() {

--- a/wasa2il/templates/core/election_detail.html
+++ b/wasa2il/templates/core/election_detail.html
@@ -208,26 +208,37 @@ function show_details() {
 
 function election_select_candidate(element) {
     $(element).hide();  // TODO: This is not doing anything
-    $(element).parent().parent().appendTo("#vote");
+    $(element).closest('li').appendTo("#vote");
     election_update();
 }
 
 function election_deselect_candidate(element) {
-    $(element).hide();
-    $(element).parent().find(".vote-up").hide();
-    $(element).parent().find(".vote-down").hide();
-    $(element).parent().find(".vote-yes").show();  // TODO: is this needed?
-    $(element).parent().parent().appendTo("#candidates");
+   $(element).closest('li').appendTo("#candidates");
     election_update();
 }
 
 function election_up_candidate(element) {
-    $(element).parent().parent().insertBefore($(element).parent().parent().prev());
+    $(element).closest('li').insertBefore($(element).closest('li').prev());
     election_update();
 }
 
 function election_down_candidate(element) {
-    $(element).parent().parent().insertAfter($(element).parent().parent().next());
+    $(element).closest('li').insertAfter($(element).closest('li').next());
+    election_update();
+}
+
+function election_top_candidate(element) {
+    $(element).closest('li').parent().prepend($(element).closest('li'));
+    election_update();
+}
+
+function election_bottom_candidate(element) {
+    $(element).closest('li').parent().append($(element).closest('li'));
+    election_update();
+}
+
+function election_freeze_candidate(element) {
+    console.log('freeze');
     election_update();
 }
 


### PR DESCRIPTION
- Added buttons which move candidates to top and bottom.
- Small jQuery and CSS refactoring

Note: do not merge yet, the freeze/pin button does nothing at the moment.
Also, need to move the candidate number CSS wise.

I am not sure if the arrows are intuitive enough, I was searching for a 'double up/down' arrows but could not find any. However I found them in another library, font awesome. Should we add that as a dependency as well? (I am not a fan of adding to many libraries)
They look like this:
http://fontawesome.io/icon/angle-double-up/

Compare it with the screenshot:
![2016-08-05_563x585](https://cloud.githubusercontent.com/assets/1689020/17449669/662b002e-5b5c-11e6-97c8-9cfcfc7f41a5.png)

Test if you feel like it and comment!
