### PR TITLE
Enable UI language choice in settings

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -8,6 +8,13 @@ from django.contrib import auth
 
 from datetime import datetime, timedelta
 
+# Put this middleware before LocaleMiddleware to ignore HTTP_ACCEPT_LANGUAGE
+# set by the browser and fall back to settings.LANGUAGE_CODE instead.
+class IgnoreHTTPAcceptLanguageMiddleware(object):
+    def process_request(self, request):
+        if request.META.has_key('HTTP_ACCEPT_LANGUAGE'):
+            del request.META['HTTP_ACCEPT_LANGUAGE']
+
 class UserSettingsMiddleware(object):
     def __init__(self):
         pass
@@ -38,5 +45,3 @@ class UserSettingsMiddleware(object):
                         and request.path_info != '/accounts/logout/'):
                     ctx = { 'auth_url': settings.SAML_1['URL'] }
                     return render_to_response('registration/verification_needed.html', ctx)
-
-

--- a/core/migrations/0007_default_language_code.py
+++ b/core/migrations/0007_default_language_code.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.db import migrations, models
+
+def reset_user_language_preference(apps, schema_editor):
+    User = apps.get_model('core', 'userprofile')
+    for user in User.objects.all():
+        user.language = settings.LANGUAGE_CODE
+        user.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0006_remove_polity_location_codes'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='userprofile',
+            name='language',
+            field=models.CharField(default=settings.LANGUAGE_CODE, max_length=b'6', verbose_name='Language', choices=settings.LANGUAGES),
+        ),
+        migrations.RunPython(reset_user_language_preference),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -49,7 +49,7 @@ class UserProfile(models.Model):
     joined_org = models.DateTimeField(null=True, blank=True) # Time when user joined organization, as opposed to registered in the system
 
     # User settings
-    language = models.CharField(max_length="6", default="en", choices=settings.LANGUAGES, verbose_name=_("Language"))
+    language = models.CharField(max_length="6", default=settings.LANGUAGE_CODE, choices=settings.LANGUAGES, verbose_name=_("Language"))
     topics_showall = models.BooleanField(default=True, help_text=_("Whether to show all topics in a polity, or only starred."))
 
     def save(self, *largs, **kwargs):

--- a/core/views.py
+++ b/core/views.py
@@ -26,6 +26,7 @@ from django.core.context_processors import csrf
 from django.core.exceptions import PermissionDenied
 from django.conf import settings
 from django.utils.translation import ugettext as _
+from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.encoding import force_bytes
 
 # BEGIN - Copied from django.contrib.auth.views to accommodate the login() function
@@ -122,6 +123,8 @@ def view_settings(request):
             request.user.save()
             form.save()
 
+            request.session[LANGUAGE_SESSION_KEY] = request.user.userprofile.language
+
             if 'picture' in request.FILES:
                 f = request.FILES.get("picture")
                 m = sha1()
@@ -183,6 +186,8 @@ def login(request, template_name='registration/login.html',
                 profile = UserProfile()
                 profile.user = request.user
                 profile.save()
+
+            request.session[LANGUAGE_SESSION_KEY] = request.user.userprofile.language
 
             if hasattr(settings, 'SAML_1'): # Is SAML 1.2 support enabled?
                 if not request.user.userprofile.user_is_verified():

--- a/wasa2il/settings.py
+++ b/wasa2il/settings.py
@@ -108,7 +108,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
-    # 'django.middleware.locale.LocaleMiddleware',
+    'core.middleware.IgnoreHTTPAcceptLanguageMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/wasa2il/templates/base.html
+++ b/wasa2il/templates/base.html
@@ -2,7 +2,7 @@
 {% load wasa2il %}
 {% load static %}
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="utf-8">
     <title>{% trans "Voting System - Pirate Party Iceland" %}{% if polity %} - {{ polity }}{% endif %}</title>


### PR DESCRIPTION
Users could change the setting but it did not have any effect. Now it works and everyone's setting is set to settings.LANGUAGE_CODE which was their only choice before, although their selection might not have matched what was displayed.