### PR TITLE
Fix top menu right margin issue, was close to edge

### DIFF
--- a/wasa2il/templates/base.html
+++ b/wasa2il/templates/base.html
@@ -34,7 +34,6 @@
         background-color: #FAFAFA;
         background-image: url("/static/img/header-bg.png");
         background-repeat: repeat-x;
-        vertical-align: center;
         height: 75px;
       }
       .navbar .navbar-brand {
@@ -72,8 +71,8 @@
     {% block head_extra %}{% endblock %}
   </head>
   <body>
-  <div class="container">
-    <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+  <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+    <div class="container">
 
         <!-- Brand and toggle get grouped for better mobile display -->
         <div class="navbar-header">
@@ -129,10 +128,10 @@
               </div>
             </div>
           </form>
-          
         </div><!-- /.navbar-collapse -->
-    </nav>
-    <div class="">
+    </div> <!-- end container -->
+  </nav>
+    <div class="container">
     {% block content %}{% endblock %}
       <footer class="footer">
         <hr/>
@@ -143,8 +142,6 @@
         <a href="/help/authors/">{% trans "Authors" %}</a>
       </footer>
     </div>
-
-  </div><!-- /.container -->
 
   </body>
 </html>


### PR DESCRIPTION
I think I broke this a while ago when I removed a container class. Fixing it now by adding the missing class :smile_cat: 

Thx to @PeterTheOne for noticing this on his PR #109 (which can be closed as well)

**Before**:
![2016-08-13_407x76](https://cloud.githubusercontent.com/assets/1689020/17645302/e660d5de-61a1-11e6-8b03-39e584d0d834.png)
**After**:
![2016-08-13_438x157](https://cloud.githubusercontent.com/assets/1689020/17645303/e674e740-61a1-11e6-84a5-22297c432d7c.png)

On a related note, it would be nice to add a button or something 'nicer' to click :smile: 