### PR TITLE
Make election/util.py not depend on Django

### DIFF
--- a/election/utils.py
+++ b/election/utils.py
@@ -6,7 +6,10 @@ import random
 import sys
 from collections import OrderedDict
 
-from django.utils.translation import ugettext_lazy as _
+if __name__ != "__main__":
+    from django.utils.translation import ugettext_lazy as _
+else:
+    _ = lambda x: x
 
 from pyvotecore.schulze_method import SchulzeMethod as Condorcet
 from pyvotecore.schulze_npr import SchulzeNPR as Schulze


### PR DESCRIPTION
We need to be able to run `election/util.py` as a standalone tool for recounts and other post-processing. This PR removes the dependency on Django when run directly.

See https://github.com/piratar/wasa2il/wiki/Elections-and-recounts for an example of the work-flows we're failing to support without this patch. :-)