### PR TITLE
Allow host: heroku development branch

### DIFF
--- a/wasa2il/default_settings.py
+++ b/wasa2il/default_settings.py
@@ -5,7 +5,7 @@
 
 # These settings are here in case no local_settings.py file is found.
 
-ALLOWED_HOSTS = ['example.com']
+ALLOWED_HOSTS = ['example.com', 'wasa2il-development.herokuapp.com']
 
 DEBUG = True
 


### PR DESCRIPTION
Trying to fix issue on:

https://wasa2il-development.herokuapp.com/

**Error:**

> Invalid HTTP_HOST header: 'wasa2il-development.herokuapp.com'. You may need to add u'wasa2il-development.herokuapp.com' to ALLOWED_HOSTS.