### PR TITLE
Add Heroku to ALLOWED_HOSTS for development

### DIFF
--- a/wasa2il/default_settings.py
+++ b/wasa2il/default_settings.py
@@ -5,7 +5,7 @@
 
 # These settings are here in case no local_settings.py file is found.
 
-ALLOWED_HOSTS = ['localhost', 'wasa2il-development.herokuapp.com']
+ALLOWED_HOSTS = ['localhost', 'wasa2il-development.herokuapp.com', 'wasa2il-staging.herokuapp.com']
 
 DEBUG = True
 

--- a/wasa2il/default_settings.py
+++ b/wasa2il/default_settings.py
@@ -5,7 +5,7 @@
 
 # These settings are here in case no local_settings.py file is found.
 
-ALLOWED_HOSTS = ['localhost']
+ALLOWED_HOSTS = ['localhost', 'wasa2il-development.herokuapp.com']
 
 DEBUG = True
 


### PR DESCRIPTION
So this website can work:
https://wasa2il-development.herokuapp.com/

This is automatically built whenever a new branch to development is pushed.