### PR TITLE
Allow for tests to run from forks as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: pip install -r requirements.txt
 script:
   - coverage run --source=. manage.py test -v 2
   - coverage xml
-  - python-codacy-coverage -r coverage.xml
+  - 'if [ "$CODACY_PROJECT_TOKEN" ]; then python-codacy-coverage -r coverage.xml; fi'
 
 deploy:
   provider: heroku


### PR DESCRIPTION
Tests would fail on PRs from forks as Travis restricts acces to secure ENV variables from PRs from this project only. See: https://blog.travis-ci.com/2016-07-07-security-advisory-encrypted-variables