### PR TITLE
Use docker-compose versioning syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,21 +4,25 @@
 # docker-compose up
 # Then migrate the database: (you might need to run it twice)
 # docker-compose run wasaweb python manage.py migrate
+version: '2'
 
-wasaweb:
-  build: .
-  volumes:
-    - .:/usr/src/app
-  ports:
-    - "8000:8000"
-  links:
-    - "db"
-  environment:
-    - DOCKER_DB_HOST=db
-db:
-  image: mysql
-  environment:
-    - MYSQL_ROOT_PASSWORD=docker
-    - MYSQL_DATABASE=docker
-    - MYSQL_USER=docker
-    - MYSQL_PASSWORD=docker
+services:
+  wasaweb:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "8000:8000"
+    links:
+      - "db"
+    environment:
+      - DOCKER_DB_HOST=db
+    depends_on:
+      - db
+  db:
+    image: mysql:5
+    environment:
+      - MYSQL_ROOT_PASSWORD=docker
+      - MYSQL_DATABASE=docker
+      - MYSQL_USER=docker
+      - MYSQL_PASSWORD=docker


### PR DESCRIPTION
Also adds `depends_on: db` so we can _try_ to make the APP container **wait** until the DB container (mysql) is ready. If mysql is not ready in time, django will **fail** to connect.

Other way is to first do
`docker-compose up db`  
wait 2-3 seconds and then do
`docker-compose up wasaweb`
which is not optimal, we prefer to use only one command.